### PR TITLE
Add CI steps for NPM publish

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -1,0 +1,228 @@
+# This workflow will do a clean install of node dependencies, build the source code,
+# run unit tests, perform a SonarCloud scan and publish NPM package ONLY on a tagged release.
+
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+# Common FOLIO configurable env:
+#   - YARN_TEST_OPTIONS (options to pass to 'yarn test')
+#   - SQ_ROOT_DIR (root SQ directory to scan relative to top-level directory)
+#   - PUBLISH_MOD_DESCRIPTOR (boolean 'true' or 'false')
+#   - COMPILE_TRANSLATION_FILES (boolean 'true' or 'false')
+
+name: buildNPM Release
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+
+jobs:
+  github-actions-ci:
+    if : ${{ startsWith(github.ref, 'refs/tags/v') }}
+    env:
+      YARN_TEST_OPTIONS: '--karma.singleRun --karma.browsers ChromeDocker --karma.reporters mocha junit --coverage'
+      SQ_ROOT_DIR: './src'
+      COMPILE_TRANSLATION_FILES: 'true'
+      PUBLISH_MOD_DESCRIPTOR: 'true'
+      FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folio/'
+      FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folio/'
+      FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
+      NODEJS_VERSION: '16'
+      JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
+      JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
+      BIGTEST_JUNIT_OUTPUT_DIR: 'artifacts/runTest'
+      BIGTEST_COVERAGE_REPORT_DIR: 'artifacts/coverage/lcov-report/'
+      OKAPI_PULL: '{ "urls" : [ "https://folio-registry.dev.folio.org" ] }'
+      SQ_LCOV_REPORT: 'artifacts/coverage-jest/lcov.info'
+      SQ_EXCLUSIONS: '**/platform/alias-service.js,**/docs/**,**/node_modules/**,**/examples/**,**/artifacts/**,**/ci/**,Jenkinsfile,**/LICENSE,**/*.css,**/*.md,**/*.json,**/tests/**,**/stories/*.js,**/test/**,**/.stories.js,**/*-test.js,**/*.test.js,**/*-spec.js,**/karma.conf.js,**/jest.config.js'
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: folio-org/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Runs a single command using the runners shell
+      - name: Print tag info
+        run: echo "Building release tag, ${GITHUB_REF}"
+
+      - name: Set TAG_VERSION
+        run: echo "TAG_VERSION=$(echo ${GITHUB_REF#refs/tags/v})" >> $GITHUB_ENV
+
+      - name: Get version from package.json
+        id: package_version
+        uses: notiz-dev/github-action-json-property@release
+        with:
+          path: 'package.json'
+          prop_path: 'version'
+
+      - name: Check matching tag and version in package.json
+        if: ${{ env.TAG_VERSION != steps.package_version.outputs.prop }}
+        run: |
+          echo "Tag version, ${TAG_VERSION}, does not match package.json version, ${PACKAGE_VERSION}."
+          exit 1
+        env:
+          PACKAGE_VERSION: ${{ steps.package_version.outputs.prop }}
+
+      - name: Setup kernel for react native, increase watchers
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODEJS_VERSION }}
+          check-latest: true
+          always-auth: true
+
+      - name: Set yarn config
+        run: yarn config set @folio:registry $FOLIO_NPM_REGISTRY
+
+      - name: Run yarn install
+        run: yarn install --ignore-scripts
+
+      - name: Run yarn list
+        run: yarn list --pattern @folio
+
+      - name: Run yarn lint
+        run: yarn lint
+        continue-on-error: true
+
+      - name: Run yarn test
+        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS
+
+      - name: Run yarn formatjs-compile
+        if : ${{ env.COMPILE_TRANSLATION_FILES == 'true' }}
+        run: yarn formatjs-compile
+
+      - name: Generate FOLIO module descriptor
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' }}
+        run: yarn build-mod-descriptor
+
+      - name: Print FOLIO module descriptor
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' }}
+        run: cat module-descriptor.json
+
+      - name: Read module descriptor
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' }}
+        id: moduleDescriptor
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./module-descriptor.json
+
+      - name: Docker registry login
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login https://docker.io/v2/ -u "${{ secrets.DOCKER_USER }}" --password-stdin
+
+      - name: Start a local instance of Okapi
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' }}
+        run: |
+          docker pull folioorg/okapi:latest
+          docker run --name okapi -t -detach folioorg/okapi:latest dev
+          echo "OKAPI_IP=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' okapi)" >> $GITHUB_ENV
+          sleep 10
+
+      - name: Pull all Module descriptors to local Okapi instance
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' }}
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: http://${{ env.OKAPI_IP }}:9130/_/proxy/pull/modules
+          method: 'POST'
+          contentType: 'application/json; charset=utf-8'
+          customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
+          data: ${{ env.OKAPI_PULL }}
+          timeout: 60000
+
+      - name: Perform local Okapi dependency check
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' }}
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: http://${{ env.OKAPI_IP }}:9130/_/proxy/modules?preRelease=false&npmSnapshot=false
+          method: 'POST'
+          contentType: 'application/json; charset=utf-8'
+          customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
+          data: ${{ steps.moduleDescriptor.outputs.content }}
+
+      - name: Publish Jest unit test results
+        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1
+        if: always()
+        with:
+          github_token: ${{ github.token }}
+          files: "${{ env.JEST_JUNIT_OUTPUT_DIR }}/*.xml"
+          check_name: Jest Unit Test Results
+          comment_mode: update last
+          comment_title: Jest Unit Test Statistics
+
+      - name: Publish Jest coverage report
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: jest-coverage-report
+          path: ${{ env.JEST_COVERAGE_REPORT_DIR }}
+          retention-days: 30
+
+      - name: Publish yarn.lock
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: yarn.lock
+          path: yarn.lock
+          retention-days: 5
+
+      - name: Set default branch as env variable
+        run: echo "DEFAULT_BRANCH=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
+
+      - name: Fetch branches for SonarCloud
+        run: git fetch --no-tags ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} +refs/heads/${{ env.DEFAULT_BRANCH }}:refs/remotes/origin/${{ env.DEFAULT_BRANCH }}
+
+      - name: Run SonarCloud scan
+        uses: sonarsource/sonarcloud-github-action@master
+        with:
+          args: >
+            -Dsonar.organization=folio-org
+            -Dsonar.projectKey=org.folio:${{ github.event.repository.name }}
+            -Dsonar.projectName=${{ github.event.repository.name }}
+            -Dsonar.sources=${{ env.SQ_ROOT_DIR }}
+            -Dsonar.language=js
+            -Dsonar.javascript.lcov.reportPaths=${{ env.SQ_LCOV_REPORT }}
+            -Dsonar.exclusions=${{ env.SQ_EXCLUSIONS }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Set up NPM environment for publishing
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODEJS_VERSION }}
+          check-latest: true
+          always-auth: true
+
+      - name: Set _auth in .npmrc
+        run: |
+          npm config set @folio:registry $FOLIO_NPM_REGISTRY
+          npm config set $FOLIO_NPM_REGISTRY_AUTH:_auth $NODE_AUTH_TOKEN
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Exclude some CI-generated artifacts in package
+        run: |
+          echo ".github" >> .npmignore
+          echo ".scannerwork" >> .npmignore
+          echo "artifacts" >> .npmignore
+          cat .npmignore
+
+      - name: Publish NPM to FOLIO NPM registry
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish module descriptor to FOLIO registry
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' }}
+        id: modDescriptorPost
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: ${{ env.FOLIO_MD_REGISTRY }}/_/proxy/modules
+          method: 'POST'
+          contentType: 'application/json; charset=utf-8'
+          customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
+          data: ${{ steps.moduleDescriptor.outputs.content }}
+          username: ${{ secrets.FOLIO_REGISTRY_USERNAME }}
+          password: ${{ secrets.FOLIO_REGISTRY_PASSWORD }}

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -1,0 +1,180 @@
+# This workflow will do a clean install of node dependencies, build the source code,
+# run unit tests, perform a Sonarqube scan, and publish NPM artifacts from master/main.
+
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+# Common FOLIO configurable environment variables to set:
+#   - YARN_TEST_OPTIONS (options to pass to 'yarn test')
+#   - SQ_ROOT_DIR (root SQ directory to scan relative to top-level directory)
+#   - PUBLISH_MOD_DESCRIPTOR (boolean 'true' or 'false')
+#   - COMPILE_TRANSLATION_FILES (boolean 'true' or 'false')
+
+
+
+name: buildNPM Snapshot
+on: [push, pull_request]
+
+jobs:
+  github-actions-ci:
+    env:
+      YARN_TEST_OPTIONS: ''
+      SQ_ROOT_DIR: './src'
+      COMPILE_TRANSLATION_FILES: 'true'
+      PUBLISH_MOD_DESCRIPTOR: 'true'
+      FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folioci/'
+      FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folioci/'
+      FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
+      NODEJS_VERSION: '16'
+      JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
+      JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
+      SQ_LCOV_REPORT: 'artifacts/coverage-jest/lcov.info'
+      SQ_EXCLUSIONS: '**/platform/alias-service.js,**/docs/**,**/node_modules/**,**/examples/**,**/artifacts/**,**/ci/**,Jenkinsfile,**/LICENSE,**/*.css,**/*.md,**/*.json,**/tests/**,**/stories/*.js,**/test/**,**/.stories.js,**/*-test.js,**/*.test.js,**/*-spec.js,**/karma.conf.js,**/jest.config.js'
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: folio-org/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Setup kernel for react native, increase watchers
+        run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODEJS_VERSION }}
+          check-latest: true
+          always-auth: true
+
+      - name: Set yarn config
+        run: yarn config set @folio:registry $FOLIO_NPM_REGISTRY
+
+      - name: Set FOLIO NPM snapshot version
+        run: |
+          git clone https://github.com/folio-org/folio-tools.git
+          npm --no-git-tag-version version `folio-tools/github-actions-scripts/folioci_npmver.sh`
+          rm -rf folio-tools
+        env:
+          JOB_ID: ${{ github.run_number }}
+
+      - name: Run yarn install
+        run: yarn install --ignore-scripts
+
+      - name: Run yarn list
+        run: yarn list --pattern @folio
+
+      - name: Run yarn lint
+        run: yarn lint
+        continue-on-error: true
+
+      - name: Run yarn test
+        run: xvfb-run --server-args="-screen 0 1024x768x24" yarn test $YARN_TEST_OPTIONS
+
+      - name: Run yarn formatjs-compile
+        if: ${{ env.COMPILE_TRANSLATION_FILES == 'true' }}
+        run: yarn formatjs-compile
+
+      - name: Generate FOLIO module descriptor
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' }}
+        run: yarn build-mod-descriptor
+
+      - name: Print FOLIO module descriptor
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' }}
+        run: cat module-descriptor.json
+
+      - name: Publish Jest unit test results
+        uses: docker://ghcr.io/enricomi/publish-unit-test-result-action:v1
+        if: always()
+        with:
+          github_token: ${{ github.token }}
+          files: "${{ env.JEST_JUNIT_OUTPUT_DIR }}/*.xml"
+          check_name: Jest Unit Test Results
+          comment_mode: update last
+          comment_title: Jest Unit Test Statistics
+
+      - name: Publish Jest coverage report
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: jest-coverage-report
+          path: ${{ env.JEST_COVERAGE_REPORT_DIR }}
+          retention-days: 30
+          
+      - name: Publish yarn.lock
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: yarn.lock
+          path: yarn.lock
+          retention-days: 5
+
+      - name: Set default branch as env variable
+        run: echo "DEFAULT_BRANCH=${{ github.event.repository.default_branch }}" >> $GITHUB_ENV
+
+      - name: Fetch branches for SonarCloud
+        run: git fetch --no-tags ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} +refs/heads/${{ env.DEFAULT_BRANCH }}:refs/remotes/origin/${{ env.DEFAULT_BRANCH }}
+
+      - name: Run SonarCloud scan
+        uses: sonarsource/sonarcloud-github-action@master
+        with:
+          args: >
+            -Dsonar.organization=folio-org
+            -Dsonar.projectKey=org.folio:${{ github.event.repository.name }}
+            -Dsonar.projectName=${{ github.event.repository.name }}
+            -Dsonar.sources=${{ env.SQ_ROOT_DIR }}
+            -Dsonar.language=js
+            -Dsonar.javascript.lcov.reportPaths=${{ env.SQ_LCOV_REPORT }}
+            -Dsonar.exclusions=${{ env.SQ_EXCLUSIONS }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Set up NPM environment for publishing
+        if: ${{ github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODEJS_VERSION }}
+          check-latest: true
+          always-auth: true
+
+      - name: Set _auth in .npmrc
+        if: ${{ github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
+        run: |
+          npm config set @folio:registry $FOLIO_NPM_REGISTRY
+          npm config set $FOLIO_NPM_REGISTRY_AUTH:_auth $NODE_AUTH_TOKEN
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Exclude some CI-generated artifacts in package
+        if: ${{ github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
+        run: |
+          echo ".github" >> .npmignore
+          echo ".scannerwork" >> .npmignore
+          echo "artifacts" >> .npmignore
+          cat .npmignore
+
+      - name: Publish NPM
+        if: ${{ github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Read module descriptor
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' && github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
+        id: moduleDescriptor
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./module-descriptor.json
+
+      - name: Publish module descriptor
+        if: ${{ env.PUBLISH_MOD_DESCRIPTOR == 'true' && github.ref == 'refs/heads/master' || github.ref  == 'refs/heads/main' }}
+        id: modDescriptorPost
+        uses: fjogeleit/http-request-action@master
+        with:
+          url: ${{ env.FOLIO_MD_REGISTRY }}/_/proxy/modules
+          method: 'POST'
+          contentType: 'application/json; charset=utf-8'
+          customHeaders: '{ "Accept": "application/json; charset=utf-8" }'
+          data: ${{ steps.moduleDescriptor.outputs.content }}
+          username: ${{ secrets.FOLIO_REGISTRY_USERNAME }}
+          password: ${{ secrets.FOLIO_REGISTRY_PASSWORD }}


### PR DESCRIPTION
We need this plugin published to NPM in order for it to be consumed. Pulled in generic build scripts used by all other FOLIO modules.