### PR TITLE
UIPQB-49 move jest-related deps to dev-deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
 * [UIPQB-26](https://issues.folio.org/browse/UIPQB-26) Validate value entered for integer property type
 * [UIPQB-43](https://issues.folio.org/browse/UIPQB-43) upgrade React to v18.
 * [UIPQB-44](https://issues.folio.org/browse/UIPQB-44) Update Node.js to v18 in GitHub Actions.
+* [UIPQB-49](https://issues.folio.org/browse/UIPQB-49) Jest-related deps are used in development only.

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "28.0.1",
     "jest-css-modules": "^2.1.0",
+    "jest-environment-jsdom": "28.1.3",
     "jest-junit": "^12.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -63,7 +64,6 @@
   "dependencies": {
     "@folio/stripes-acq-components": "~5.0.0",
     "@tanstack/react-query": "4.29.5",
-    "jest-environment-jsdom": "28.1.3",
     "ky": "^0.33.2",
     "lodash": "^4.17.5",
     "moment": "^2.29.4",


### PR DESCRIPTION
Jest-related deps are used in development only and therefore must be dev-deps, not regular deps.

Refs [UIPQB-49](https://issues.folio.org/browse/UIPQB-49)

