### PR TITLE
UIPQB-64 Query builder can’t edit single condition queries without AND wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## (in progress)
 * [UIPQB-60](https://issues.folio.org/browse/UIPQB-60) 'In' and 'Not In' requests not properly formatted for [Users] "User ID"
 * [UIPQB-56](https://issues.folio.org/browse/UIPQB-56) Prevent columns from being reset when query is changed
+* [UIPQB-64](https://issues.folio.org/browse/UIPQB-64) Query builder can’t edit single condition queries without AND wrapper
 
 ## [1.0.0](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.0.0) (2023-10-12)
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
@@ -14,7 +14,7 @@ import { QueryBuilderTitle } from '../../QueryBuilderTitle';
 import css from '../QueryBuilderModal.css';
 import { COLUMN_KEYS } from '../../../../constants/columnKeys';
 import { booleanOptions, getFieldOptions, getOperatorOptions, sourceTemplate } from '../../helpers/selectOptions';
-import { OPERATORS } from '../../../../constants/operators';
+import { BOOLEAN_OPERATORS } from '../../../../constants/operators';
 import { DataTypeInput } from '../DataTypeInput';
 
 export const RepeatableFields = ({ source, setSource, getParamsSource, columns }) => {
@@ -27,7 +27,7 @@ export const RepeatableFields = ({ source, setSource, getParamsSource, columns }
       ...res,
       {
         ...sourceTemplate(fieldOptions),
-        [COLUMN_KEYS.BOOLEAN]: { options: booleanOptions, current: OPERATORS.AND },
+        [COLUMN_KEYS.BOOLEAN]: { options: booleanOptions, current: BOOLEAN_OPERATORS.AND },
       },
     ]));
   };

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -101,7 +101,9 @@ const getQueryOperand = (item) => {
 
 export const sourceToMongoQuery = (source) => {
   const query = {};
-  const boolOperator = source.find(item => Boolean(item.boolean.current))?.boolean.current;
+  // A temporary solution to searching for the first operand and its operator, since we only support one at the moment.
+  const firstOperand = source.find(item => Boolean(item.boolean.current));
+  const boolOperator = firstOperand?.boolean.current;
   const queryOperands = source.map(getQueryOperand);
 
   if (boolOperator) {

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -185,16 +185,24 @@ export const mongoQueryToSource = async ({
 
   // handle case when query contains boolean operators (AND, OR, etc.)
   if (Object.values(BOOLEAN_OPERATORS).includes(key)) {
-    return initialValues[key].map((item) => getFormattedSourceField({
-      item,
-      ...sharedArgs,
-    }));
+    const formattedSource = [];
+
+    for (const item of initialValues[key]) {
+      const formattedItem = await getFormattedSourceField({
+        item,
+        ...sharedArgs,
+      });
+
+      formattedSource.push(formattedItem);
+    }
+
+    return formattedSource;
   }
 
-  return [
-    getFormattedSourceField({
-      item: initialValues,
-      ...sharedArgs,
-    }),
-  ];
+  const singleItem = await getFormattedSourceField({
+    item: initialValues,
+    ...sharedArgs,
+  });
+
+  return [singleItem];
 };

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -130,7 +130,7 @@ const getSourceFields = (field) => ({
   },
 }[field]);
 
-const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOptions, getParamsSource }) => {
+const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOptions, getParamsSource, boolean }) => {
   const [field, query] = Object.entries(item)[0];
   const mongoOperator = Object.keys(query)[0];
   const mongoValue = query[mongoOperator];
@@ -138,7 +138,6 @@ const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOption
   const { operator, value } = getSourceFields(mongoOperator)(mongoValue);
 
   if (operator && value) {
-    const boolean = BOOLEAN_OPERATORS.AND;
     const fieldItem = fieldOptions.find(f => f.value === field);
     const { dataType, values, source } = fieldItem;
     const hasSourceOrValues = values || source;
@@ -169,6 +168,8 @@ const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOption
       value: { current: formattedValue || value, source, options: values },
     };
   }
+
+  return null;
 };
 
 export const mongoQueryToSource = async ({
@@ -190,6 +191,7 @@ export const mongoQueryToSource = async ({
     for (const item of initialValues[key]) {
       const formattedItem = await getFormattedSourceField({
         item,
+        boolean: key,
         ...sharedArgs,
       });
 
@@ -201,6 +203,7 @@ export const mongoQueryToSource = async ({
 
   const singleItem = await getFormattedSourceField({
     item: initialValues,
+    boolean: '',
     ...sharedArgs,
   });
 

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -178,7 +178,7 @@ export const mongoQueryToSource = async ({
   intl,
   getParamsSource,
 }) => {
-  if (!fieldOptions?.length) return [];
+  if (!fieldOptions?.length || !Object.keys(initialValues).length) return [];
 
   const key = Object.keys(initialValues)[0];
   const sharedArgs = { intl, booleanOptions, getParamsSource, fieldOptions };

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -10,6 +10,7 @@ describe('mongoQueryToSource()', () => {
       booleanOptions,
       fieldOptions,
       intl: { formatMessage: jest.fn() },
+      getParamsSource: jest.fn(),
     });
 
     expect(result).toEqual([]);

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -17,62 +17,62 @@ describe('mongoQueryToSource()', () => {
 
   const source = [
     {
-      boolean: { options: booleanOptions, current: 'AND' },
+      boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'user_first_name' },
       operator: { options: expect.any(Array), current: OPERATORS.EQUAL },
       value: { current: 'value' },
     },
     {
-      boolean: { options: booleanOptions, current: 'AND' },
+      boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'user_first_name' },
       operator: { options: expect.any(Array), current: OPERATORS.NOT_EQUAL },
       value: { current: 'value' },
     },
     {
-      boolean: { options: booleanOptions, current: 'AND' },
+      boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'user_last_name' },
       operator: { options: expect.any(Array), current: OPERATORS.GREATER_THAN },
       value: { current: 'value' },
     },
     {
-      boolean: { options: booleanOptions, current: 'AND' },
+      boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'user_last_name' },
       operator: { options: expect.any(Array), current: OPERATORS.LESS_THAN },
       value: { current: 10 },
     },
     {
-      boolean: { options: booleanOptions, current: 'AND' },
+      boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'user_last_name' },
       operator: { options: expect.any(Array), current: OPERATORS.GREATER_THAN_OR_EQUAL },
       value: { current: 'value' },
     },
 
     {
-      boolean: { options: booleanOptions, current: 'AND' },
+      boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'languages' },
       operator: { options: expect.any(Array), current: OPERATORS.IN },
       value: { current: [{ label: 'value', value: 'value' }, { label: 'value2', value: 'value2' }] },
     },
     {
-      boolean: { options: booleanOptions, current: 'AND' },
+      boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'user_full_name' },
       operator: { options: expect.any(Array), current: OPERATORS.CONTAINS },
       value: { current: 'abc' },
     },
     {
-      boolean: { options: booleanOptions, current: 'AND' },
+      boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'languages' },
       operator: { options: expect.any(Array), current: OPERATORS.NOT_IN },
       value: { current: [{ label: 'value', value: 'value' }, { label: 'value2', value: 'value2' }] },
     },
     {
-      boolean: { options: booleanOptions, current: 'AND' },
+      boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'user_id' },
       operator: { options: expect.any(Array), current: OPERATORS.NOT_IN },
       value: { current: 'value, value2' },
     },
     {
-      boolean: { options: booleanOptions, current: 'AND' },
+      boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'user_id' },
       operator: { options: expect.any(Array), current: OPERATORS.IN },
       value: { current: 'value, value2' },

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -16,6 +16,13 @@ describe('mongoQueryToSource()', () => {
     expect(result).toEqual([]);
   });
 
+  const singleSource = [{
+    boolean: { options: [{ label: 'AND', value: '' }], current: '' },
+    field: { options: fieldOptions, current: 'user_first_name', dataType: 'stringType' },
+    operator: { options: expect.any(Array), current: OPERATORS.EQUAL, dataType: 'stringType' },
+    value: { current: 'value', options: undefined, source: undefined },
+  }];
+
   const source = [
     {
       boolean: { options: booleanOptions, current: '$and' },
@@ -132,6 +139,17 @@ describe('mongoQueryToSource()', () => {
     })));
   });
 
+  it('should convert single query without operators to source format', async () => {
+    const result = await mongoQueryToSource({
+      initialValues: { user_first_name: { $eq: 'value' } },
+      booleanOptions: [{ label: 'AND', value: '' }],
+      fieldOptions,
+      intl: { formatMessage: jest.fn() },
+    });
+
+    expect(result).toEqual(singleSource);
+  });
+
   it('should convert from source to simple query format', () => {
     const initial = {
       $and: [
@@ -149,6 +167,14 @@ describe('mongoQueryToSource()', () => {
     };
 
     const result = sourceToMongoQuery(source);
+
+    expect(result).toEqual(initial);
+  });
+
+  it('should convert from SINGLE source to simple query format', () => {
+    const initial = { user_first_name: { $eq: 'value' } };
+
+    const result = sourceToMongoQuery(singleSource);
 
     expect(result).toEqual(initial);
   });

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -1,5 +1,5 @@
 import { DATA_TYPES } from '../../../constants/dataTypes';
-import { OPERATORS } from '../../../constants/operators';
+import { BOOLEAN_OPERATORS, OPERATORS } from '../../../constants/operators';
 import { COLUMN_KEYS } from '../../../constants/columnKeys';
 
 const getOperatorsWithPlaceholder = (options, intl) => {
@@ -106,7 +106,7 @@ export const getFieldOptions = (options) => {
 };
 
 export const booleanOptions = [
-  { label: 'AND', value: OPERATORS.AND },
+  { label: 'AND', value: BOOLEAN_OPERATORS.AND },
 ];
 
 export const sourceTemplate = (fieldOptions = []) => ({

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -106,7 +106,7 @@ export const getFieldOptions = (options) => {
 };
 
 export const booleanOptions = [
-  { label: 'AND', value: 'AND' },
+  { label: 'AND', value: OPERATORS.AND },
 ];
 
 export const sourceTemplate = (fieldOptions = []) => ({

--- a/src/constants/operators.js
+++ b/src/constants/operators.js
@@ -9,5 +9,5 @@ export const OPERATORS = {
   NOT_IN: 'not in',
   CONTAINS: 'contains',
   STARTS_WITH: 'starts with',
-  AND: 'AND',
+  AND: '$and',
 };

--- a/src/constants/operators.js
+++ b/src/constants/operators.js
@@ -9,5 +9,8 @@ export const OPERATORS = {
   NOT_IN: 'not in',
   CONTAINS: 'contains',
   STARTS_WITH: 'starts with',
+};
+
+export const BOOLEAN_OPERATORS = {
   AND: '$and',
 };


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODORDERS-70 Orders schema updates
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders
  which is currently missing in the schema"
  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."
  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODORDERS-70
 -->
https://issues.folio.org/browse/UIPQB-64

- Added support of both variants `$and: [{field: $eq: 'value'}]` and just `{field: $eq: 'value'}` if value is single.
- Refactored constants
- Updated tests

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.
 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [ ] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] If any API-related changes - okapi interfaces and permissions are reviewed/changed correspondingly
  - [ ] There are no breaking changes in this PR.

If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
