### PR TITLE
UIPQB-70 Array fields support verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,4 @@
 * [UIPQB-51](https://issues.folio.org/browse/UIPQB-51) Dropdown typeahead should use contains not starts with.
 * [UIPQB-57](https://issues.folio.org/browse/UIPQB-57) 400 error should be reported in the UI
 * [UIPQB-55](https://issues.folio.org/browse/UIPQB-55) Regular expressions are incorrect for contains and starts_with operators
+* [UIPQB-70](https://issues.folio.org/browse/UIPQB-70) Array fields support verification

--- a/src/QueryBuilder/ResultViewer/helpers.js
+++ b/src/QueryBuilder/ResultViewer/helpers.js
@@ -25,7 +25,7 @@ export const getTableMetadata = (entityType) => {
       if (dataType === DATA_TYPES.DateType) {
         return <FormattedDate value={item[value]} />;
       } else if (dataType === DATA_TYPES.ArrayType) {
-        return item[value]?.join('|');
+        return item[value]?.join(' | ');
       } else {
         // If value is empty we will return empty string
         // instead of undefined


### PR DESCRIPTION
Based on comment in [UIPQB-70](https://issues.folio.org/browse/UIPQB-70), delimeter should be ' | ' but not '|'.