### PR TITLE
UIPQB-80: Add operators for NumberType and adjust operators for IntegerType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [UIPQB-66](https://issues.folio.org/browse/UIPQB-66) Localize dates in results view.
 * [UIPQB-54](https://issues.folio.org/browse/UIPQB-54) Add support for array fields in query results.
 * [UIPQB-70](https://issues.folio.org/browse/UIPQB-70) Array fields support verification.
+* [UIPQB-80](https://issues.folio.org/browse/UIPQB-80) Add operators for NumberType and adjust operators for IntegerType.
 
 ## [1.0.0](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.0.0) (2023-10-12)
 

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -79,8 +79,12 @@ export const getOperatorOptions = ({
 
     case DATA_TYPES.OpenUUIDType:
       return getOperatorsWithPlaceholder(UUIDOperators(), intl);
+
     case DATA_TYPES.IntegerType:
-      return getOperatorsWithPlaceholder(baseLogicalOperators(), intl);
+      return getOperatorsWithPlaceholder(extendedLogicalOperators(), intl);
+
+    case DATA_TYPES.NumberType:
+      return getOperatorsWithPlaceholder(extendedLogicalOperators(), intl);
 
     case DATA_TYPES.ArrayType:
       return getOperatorsWithPlaceholder(ArrayOperators(), intl);

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -115,7 +115,7 @@ describe('select options', () => {
       });
     });
 
-    it('should return base logical operators with placeholder for integer type', () => {
+    it('should return extended logical operators with placeholder for integer type', () => {
       const options = getOperatorOptions({
         dataType: DATA_TYPES.IntegerType,
         hasSourceOrValues: false,
@@ -129,6 +129,28 @@ describe('select options', () => {
           { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
           { label: OPERATORS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
           { label: OPERATORS.LESS_THAN, value: OPERATORS.LESS_THAN },
+          { label: OPERATORS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
+          { label: OPERATORS.LESS_THAN_OR_EQUAL, value: OPERATORS.LESS_THAN_OR_EQUAL },
+        ],
+      });
+    });
+
+    it('should return extended logical operators with placeholder for number type', () => {
+      const options = getOperatorOptions({
+        dataType: DATA_TYPES.NumberType,
+        hasSourceOrValues: false,
+        intl: intlMock,
+      });
+
+      expectFn({
+        options,
+        operators: [
+          { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
+          { label: OPERATORS.LESS_THAN, value: OPERATORS.LESS_THAN },
+          { label: OPERATORS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
+          { label: OPERATORS.LESS_THAN_OR_EQUAL, value: OPERATORS.LESS_THAN_OR_EQUAL },
         ],
       });
     });

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
@@ -27,6 +27,8 @@ export const valueBuilder = ({ value, field, operator, fieldOptions }) => {
 
     [DATA_TYPES.IntegerType]: () => (isArray ? getCommaSeparatedStr(value) : value),
 
+    [DATA_TYPES.NumberType]: () => (isArray ? getCommaSeparatedStr(value) : value),
+
     [DATA_TYPES.RangedUUIDType]: () => getQuotedStr(value),
 
     [DATA_TYPES.ArrayType]: () => (isArray ? getCommaSeparatedStr(value) : getQuotedStr(value)),

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.test.js
@@ -21,6 +21,14 @@ describe('valueBuilder', () => {
     expect(valueBuilder({ value, field, operator, fieldOptions })).toBe(value);
   });
 
+  test('should return the same value for NumberType', () => {
+      const value = 42.1;
+      const field = 'decimal_position';
+      const operator = OPERATORS.EQUAL;
+
+      expect(valueBuilder({ value, field, operator, fieldOptions })).toBe(value);
+    });
+
   test('should return a string enclosed in double quotes for BooleanType', () => {
     const value = true;
     const field = 'user_active';

--- a/test/jest/data/entityType.js
+++ b/test/jest/data/entityType.js
@@ -284,6 +284,14 @@ export const entityType = {
       'visibleByDefault': true,
     },
     {
+      'name': 'decimal_position',
+      'dataType': {
+        'dataType': 'numberType',
+      },
+      'labelAlias': 'Decimal position',
+      'visibleByDefault': true,
+    },
+    {
       'name': 'item_material_type',
       'dataType': {
         'dataType': 'stringType',


### PR DESCRIPTION
## Purpose
[UIPQB-80](https://folio-org.atlassian.net/browse/UIPQB-80): Add operators for NumberType and adjust operators for IntegerType

The purpose of this PR is to make certain operators available for NumberType columns in the query builder. While doing this, I noticed that >= and <= were not available for IntegerTypes, so I added those operators to the IntegerType as well.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.
