### PR TITLE
UIPQB-71 AAllow dropdown menus for array types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,4 @@
 * [UIPQB-57](https://issues.folio.org/browse/UIPQB-57) 400 error should be reported in the UI
 * [UIPQB-55](https://issues.folio.org/browse/UIPQB-55) Regular expressions are incorrect for contains and starts_with operators
 * [UIPQB-70](https://issues.folio.org/browse/UIPQB-70) Array fields support verification
+* [UIPQB-71](https://issues.folio.org/browse/UIPQB-71) Allow dropdown menus for array types

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
@@ -28,7 +28,7 @@ export const DataTypeInput = ({
 }) => {
   const isInRelatedOperator = [OPERATORS.IN, OPERATORS.NOT_IN].includes(operator);
   const isEqualRelatedOperator = [OPERATORS.EQUAL, OPERATORS.NOT_EQUAL].includes(operator);
-  const isContainsOperator = operator === OPERATORS.CONTAINS;
+  const isContainsRelatedOperator = [OPERATORS.CONTAINS, OPERATORS.NOT_CONTAINS].includes(operator);
   const hasSourceOrValues = source || availableValues;
 
   const textControl = ({ testId, type = 'text', textClass }) => {
@@ -169,7 +169,7 @@ export const DataTypeInput = ({
       return openUUIDTypeControls();
 
     case DATA_TYPES.ArrayType:
-      return isContainsOperator && hasSourceOrValues
+      return isContainsRelatedOperator && hasSourceOrValues
         ? selectControl({ testId: 'data-input-select-array' })
         : textControl({ testId: 'data-input-text-arrayType' });
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
@@ -28,6 +28,7 @@ export const DataTypeInput = ({
 }) => {
   const isInRelatedOperator = [OPERATORS.IN, OPERATORS.NOT_IN].includes(operator);
   const isEqualRelatedOperator = [OPERATORS.EQUAL, OPERATORS.NOT_EQUAL].includes(operator);
+  const isContainsOperator = operator === OPERATORS.CONTAINS;
   const hasSourceOrValues = source || availableValues;
 
   const textControl = ({ testId, type = 'text', textClass }) => {
@@ -168,7 +169,9 @@ export const DataTypeInput = ({
       return openUUIDTypeControls();
 
     case DATA_TYPES.ArrayType:
-      return textControl({ testId: 'data-input-text-arrayType' });
+      return isContainsOperator && hasSourceOrValues
+        ? selectControl({ testId: 'data-input-select-array' })
+        : textControl({ testId: 'data-input-text-arrayType' });
 
     case DATA_TYPES.EnumType:
       return arrayLikeTypeControls();


### PR DESCRIPTION
Render dropdown menu for arrayType when operators are contains or not_contains. Ref: [UIPQB-71](https://folio-org.atlassian.net/browse/UIPQB-71)

![image](https://github.com/folio-org/ui-plugin-query-builder/assets/86330150/99dc501d-dc77-4228-98d7-b7cc7bf0bd36)
