### PR TITLE
[UIPQB-85] Use non-id columns for queries

### DIFF
--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import {
   Modal,
@@ -21,12 +21,13 @@ import { useEntityType } from '../../../hooks/useEntityType';
 import { useCancelQuery } from '../../../hooks/useCancelQuery';
 import { useTestQuery } from '../../../hooks/useTestQuery';
 import { getFieldOptions } from '../helpers/selectOptions';
+import upgradeInitialValues from '../helpers/upgradeInitialValues';
 
 export const QueryBuilderModal = ({
   isOpen,
   setIsModalShown,
   saveBtnLabel,
-  initialValues,
+  initialValues: originalInitialValues,
   entityTypeDataSource,
   runQueryDataSource,
   testQueryDataSource,
@@ -47,6 +48,11 @@ export const QueryBuilderModal = ({
   const { entityType } = useEntityType({ entityTypeDataSource });
 
   const { cancelQuery } = useCancelQuery({ cancelQueryDataSource });
+
+  const initialValues = useMemo(
+    () => upgradeInitialValues(originalInitialValues, entityType),
+    [originalInitialValues, entityType],
+  );
 
   const {
     source,

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -111,7 +111,7 @@ export const getFieldOptions = (options) => {
 
   return options?.filter(o => !ids.includes(o.name)).map(o => ({
     label: o.labelAlias,
-    value: o.idColumnName || o.name,
+    value: o.name,
     dataType: o.dataType.dataType,
     source: o.source,
     values: getFilledValues(o.values),

--- a/src/QueryBuilder/QueryBuilder/helpers/upgradeInitialValues.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/upgradeInitialValues.js
@@ -1,0 +1,24 @@
+/**
+ * Upgrades initial values to indirectly reference id columns (e.g. vendor_code instead of vendor_id).
+ * FQM used to previously require vendor_id, but this was changed in MODFQMMGR-151 to allow for better expression
+ * and to allow for more flexibility in the future.
+ */
+export default function upgradeInitialValues(initialValues, entityType) {
+  const idColumnMapping = {};
+
+  entityType?.columns.forEach((column) => {
+    if (column.idColumnName) {
+      idColumnMapping[column.idColumnName] = column.name;
+    }
+  });
+
+  const upgradedInitialValues = {};
+
+  Object.keys(initialValues).forEach((key) => {
+    const newKey = idColumnMapping[key] || key;
+
+    upgradedInitialValues[newKey] = initialValues[key];
+  });
+
+  return upgradedInitialValues;
+}


### PR DESCRIPTION
# [Jira UIPQB-85](https://folio-org.atlassian.net/browse/UIPQB-85)

## Purpose
We've extended FQL to support using non-ID columns in place of their normal IDs (e.g. `vendor_code`/`vendor_name` instead of `vendor_id`).

This changes the query builder to:
1. Build queries using these column names instead of the old `idColumnName`
2. Handle "legacy" queries which still use `vendor_id` and map them to `vendor_code` silently, to be saved upon edit.

> [!NOTE]
> The result viewer still shows an incorrect user friendly query for `vendor_code` and other derived columns, which must be converted on the backend.  [MODLISTS-85](https://folio-org.atlassian.net/browse/MODLISTS-85) has been created to fix this.