### PR TITLE
UIPQB-84: Results viewer doesn't show 0 value for number type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [UIPQB-80](https://issues.folio.org/browse/UIPQB-80) Add operators for NumberType and adjust operators for IntegerType.
 * [UIPQB-73](https://folio-org.atlassian.net/browse/UIPQB-73) Result Viewer shows current date if date column is not present.
 * [UIPQB-82](https://folio-org.atlassian.net/browse/UIPQB-82) [Query Builder] Support querying based on nested objects within arrays.
+* [UIPQB-84](https://folio-org.atlassian.net/browse/UIPQB-84) Results viewer doesn't show 0 value for number type.
 
 ## [1.0.0](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.0.0) (2023-10-12)
 

--- a/src/QueryBuilder/ResultViewer/helpers.js
+++ b/src/QueryBuilder/ResultViewer/helpers.js
@@ -30,6 +30,12 @@ export const getTableMetadata = (entityType) => {
         return item[value] ? <FormattedDate value={item[value]} /> : '';
       } else if (dataType === DATA_TYPES.ArrayType) {
         return item[value]?.join(' | ');
+      } else if (dataType === DATA_TYPES.NumberType) {
+        if (item[value] === undefined) {
+          return '';
+        }
+
+        return item[value];
       } else {
         // If value is empty we will return empty string
         // instead of undefined


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-84
Here we added case for handling 0 value in `numberType`


https://github.com/folio-org/ui-plugin-query-builder/assets/72550466/e3d6374a-cb5d-41d4-b0bf-f82bcdb3100f

