### PR TITLE
UIPQB-95 Disable run query button when records limit exceeded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * [UIPQB-84](https://folio-org.atlassian.net/browse/UIPQB-84) Results viewer doesn't show 0 value for number type.
 * [UIPQB-78](https://folio-org.atlassian.net/browse/UIPQB-78) Query builder display if no records match the query
 * [UIPQB-74](https://folio-org.atlassian.net/browse/UIPQB-74)Non-default fields that are part of the query are automatically displayed as columns
+* [UIPQB-95](https://folio-org.atlassian.net/browse/UIPQB-95) Disable run query button when records limit exceeded
 
 ## [1.0.0](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.0.0) (2023-10-12)
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
@@ -71,6 +71,7 @@ export const QueryBuilderModal = ({
   });
 
   const [isQueryRetrieved, setIsQueryRetrieved] = useState(false);
+  const [recordsLimitExceeded, setRecordsLimitExceeded] = useState(false);
 
   const {
     queryId,
@@ -164,9 +165,10 @@ export const QueryBuilderModal = ({
   }, [source, isTestQueryInProgress]);
 
   const isRunQueryDisabled = !isQueryRetrieved
-      || !isQueryFilled
-      || isRunQueryLoading
-      || (!canRunEmptyQuery && entityType?.columns);
+    || !isQueryFilled
+    || isRunQueryLoading
+    || (!canRunEmptyQuery && entityType?.columns)
+    || recordsLimitExceeded;
 
   const renderFooter = () => (
     <ModalFooter>
@@ -234,6 +236,8 @@ export const QueryBuilderModal = ({
             setIsPreviewLoading={setIsPreviewLoading}
             isTestQueryInProgress={isTestQueryInProgress}
             setIsTestQueryInProgress={setIsTestQueryInProgress}
+            recordsLimitExceeded={recordsLimitExceeded}
+            setRecordsLimitExceeded={setRecordsLimitExceeded}
             recordsLimit={recordsLimit}
             additionalControls={additionalControls}
           />

--- a/src/QueryBuilder/QueryBuilder/TestQuery/TestQuery.js
+++ b/src/QueryBuilder/QueryBuilder/TestQuery/TestQuery.js
@@ -28,6 +28,8 @@ export const TestQuery = ({
   setIsPreviewLoading,
   isTestQueryInProgress,
   setIsTestQueryInProgress,
+  recordsLimitExceeded,
+  setRecordsLimitExceeded,
   recordsLimit,
   forcedVisibleValues,
 }) => {
@@ -37,7 +39,6 @@ export const TestQuery = ({
   const [visibleColumns, setVisibleColumns] = useState(recordColumns);
 
   const [includeContent, setIncludeContent] = useState(true);
-  const [recordsLimitExceeded, setRecordsLimitExceeded] = useState(false);
 
   const isTestQueryBtnDisabled = isTestQueryLoading || !isQueryFilled || isTestQueryInProgress;
 
@@ -207,6 +208,8 @@ TestQuery.propTypes = {
   setIsPreviewLoading: PropTypes.func,
   isTestQueryInProgress: PropTypes.bool,
   setIsTestQueryInProgress: PropTypes.func,
+  recordsLimitExceeded: PropTypes.bool,
+  setRecordsLimitExceeded: PropTypes.func,
   recordsLimit: PropTypes.number,
   recordColumns: PropTypes.arrayOf(PropTypes.string),
   forcedVisibleValues: PropTypes.arrayOf(PropTypes.string),


### PR DESCRIPTION
Aded condition for "run button", if limit exceeded then button will be disabled. Refs [UIPQB-95](https://folio-org.atlassian.net/browse/UIPQB-95)