### PR TITLE
UIPQB-96 Extend runQuery handler with "user-friendly" query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * [UIPQB-78](https://folio-org.atlassian.net/browse/UIPQB-78) Query builder display if no records match the query
 * [UIPQB-74](https://folio-org.atlassian.net/browse/UIPQB-74)Non-default fields that are part of the query are automatically displayed as columns
 * [UIPQB-95](https://folio-org.atlassian.net/browse/UIPQB-95) Disable run query button when records limit exceeded
+* [UIPQB-96](https://folio-org.atlassian.net/browse/UIPQB-96) Extend runQuery handler with "user-friendly" query param
 
 ## [1.0.0](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.0.0) (2023-10-12)
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
@@ -145,6 +145,7 @@ export const QueryBuilderModal = ({
     await runQuery({
       queryId,
       fqlQuery,
+      queryStr,
     });
 
     await handleCloseModal(false);

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
@@ -145,7 +145,7 @@ export const QueryBuilderModal = ({
     await runQuery({
       queryId,
       fqlQuery,
-      queryStr,
+      userFriendlyQuery: queryStr,
     });
 
     await handleCloseModal(false);

--- a/src/hooks/useRunQuery.js
+++ b/src/hooks/useRunQuery.js
@@ -2,7 +2,11 @@ import { useMutation } from '@tanstack/react-query';
 
 export const useRunQuery = ({ runQueryDataSource, onQueryRunSuccess, onQueryRunFail }) => {
   const { mutateAsync: runQuery, isLoading: isRunQueryLoading } = useMutation({
-    mutationFn: ({ queryId, fqlQuery }) => runQueryDataSource({ queryId, fqlQuery }),
+    mutationFn: ({ queryId, fqlQuery, userFriendlyQuery }) => runQueryDataSource({
+      queryId,
+      fqlQuery,
+      userFriendlyQuery,
+    }),
     onSuccess: onQueryRunSuccess,
     onError: onQueryRunFail,
   });


### PR DESCRIPTION
 Extend runQuery handler with user friendly query string. Required for implementation of [UIBULKED-426](https://folio-org.atlassian.net/browse/UIBULKED-426)