### PR TITLE
UIPQB-95 clear state after query closed

### DIFF
--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
@@ -115,6 +115,7 @@ export const QueryBuilderModal = ({
     if (queryId) {
       setIsTestQueryInProgress(false);
       setIsPreviewLoading(false);
+      setRecordsLimitExceeded(false);
 
       queryClient.removeQueries({ queryKey: [QUERY_KEYS.QUERY_PLUGIN_CONTENT_DATA] });
 


### PR DESCRIPTION
It's required clear banner after query plugin was closed. 