### PR TITLE
UIPQB-101: It's not possible to edit list when operator is null/empty

### DIFF
--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -167,7 +167,7 @@ const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOption
 
   const { operator, value } = getSourceFields(mongoOperator)(mongoValue);
 
-  if (operator && value) {
+  if (operator) {
     const fieldItem = fieldOptions.find(f => f.value === field);
     const { dataType, values, source } = fieldItem;
     const hasSourceOrValues = values || source;

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -105,6 +105,12 @@ describe('mongoQueryToSource()', () => {
       operator: { options: expect.any(Array), current: OPERATORS.EMPTY },
       value: { current: true },
     },
+    {
+      boolean: { options: booleanOptions, current: '$and' },
+      field: { options: fieldOptions, current: 'department_ids', dataType: DATA_TYPES.ArrayType },
+      operator: { options: expect.any(Array), current: OPERATORS.EMPTY },
+      value: { current: false },
+    },
   ];
 
   const initialValues = {
@@ -122,6 +128,7 @@ describe('mongoQueryToSource()', () => {
       { department_names: { $contains: 'value' } },
       { department_names: { $not_contains: 'value' } },
       { department_ids: { $empty: true } },
+      { department_ids: { $empty: false } },
     ],
   };
 
@@ -189,6 +196,7 @@ describe('mongoQueryToSource()', () => {
         { department_names: { $contains: 'value' } },
         { department_names: { $not_contains: 'value' } },
         { department_ids: { $empty: true } },
+        { department_ids: { $empty: false } },
       ],
     };
 


### PR DESCRIPTION
[UIPQB-101: It's not possible to edit list when operator is null/empty](https://github.com/folio-org/ui-plugin-query-builder/pull/105/commits/0c119028363fcbcf785b771b05fb3b88a3420a45)