### PR TITLE
UIPQB-86 The IN operator is incorrectly rendered in the query builder when editing existing queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * [UIPQB-74](https://folio-org.atlassian.net/browse/UIPQB-74)Non-default fields that are part of the query are automatically displayed as columns
 * [UIPQB-95](https://folio-org.atlassian.net/browse/UIPQB-95) Disable run query button when records limit exceeded
 * [UIPQB-96](https://folio-org.atlassian.net/browse/UIPQB-96) Extend runQuery handler with "user-friendly" query param
+* [UIPQB-86](https://folio-org.atlassian.net/browse/UIPQB-86) The IN operator is incorrectly rendered in the query builder when editing existing queries
 
 ## [1.0.0](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.0.0) (2023-10-12)
 

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -174,11 +174,15 @@ const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOption
     let formattedValue;
 
     if (Array.isArray(value) && hasSourceOrValues) {
-      const params = source ? await getParamsSource?.({
-        entityTypeId: source?.entityTypeId,
-        columnName: source?.columnName,
-        searchValue: '',
-      }).then((data) => data?.content) : values;
+      let params = values;
+
+      if (source) {
+        params = await getParamsSource?.({
+          entityTypeId: source?.entityTypeId,
+          columnName: source?.columnName,
+          searchValue: '',
+        }).then((data) => data?.content);
+      }
 
       formattedValue = value.map(val => params?.find(param => param.value === val));
     }

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -173,14 +173,14 @@ const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOption
     const hasSourceOrValues = values || source;
     let formattedValue;
 
-    if (Array.isArray(value) && source) {
-      const params = await getParamsSource?.({
+    if (Array.isArray(value) && hasSourceOrValues) {
+      const params = source ? await getParamsSource?.({
         entityTypeId: source?.entityTypeId,
         columnName: source?.columnName,
         searchValue: '',
-      });
+      }).then((data) => data?.content) : values;
 
-      formattedValue = value.map(val => params?.content?.find(param => param.value === val));
+      formattedValue = value.map(val => params?.find(param => param.value === val));
     }
 
     return {

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -133,8 +133,8 @@ describe('mongoQueryToSource()', () => {
       { department_names: { $contains: 'value' } },
       { department_names: { $not_contains: 'value' } },
       { department_ids: { $empty: true } },
-      { languages: { $in: ['value', 'value2'] } },
       { department_ids: { $empty: false } },
+      { languages: { $in: ['value', 'value2'] } },
     ],
   };
 

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -56,24 +56,11 @@ describe('mongoQueryToSource()', () => {
       operator: { options: expect.any(Array), current: OPERATORS.GREATER_THAN_OR_EQUAL },
       value: { current: 'value' },
     },
-
-    {
-      boolean: { options: booleanOptions, current: '$and' },
-      field: { options: fieldOptions, current: 'languages' },
-      operator: { options: expect.any(Array), current: OPERATORS.IN },
-      value: { current: [{ label: 'value', value: 'value' }, { label: 'value2', value: 'value2' }] },
-    },
     {
       boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'user_full_name' },
       operator: { options: expect.any(Array), current: OPERATORS.CONTAINS },
       value: { current: 'abc' },
-    },
-    {
-      boolean: { options: booleanOptions, current: '$and' },
-      field: { options: fieldOptions, current: 'languages' },
-      operator: { options: expect.any(Array), current: OPERATORS.NOT_IN },
-      value: { current: [{ label: 'value', value: 'value' }, { label: 'value2', value: 'value2' }] },
     },
     {
       boolean: { options: booleanOptions, current: '$and' },
@@ -107,6 +94,26 @@ describe('mongoQueryToSource()', () => {
     },
   ];
 
+  const sourceFromUI = [
+    ...source,
+    {
+      boolean: { options: booleanOptions, current: '$and' },
+      field: { options: fieldOptions, current: 'languages' },
+      operator: { options: expect.any(Array), current: OPERATORS.IN },
+      value: { current: [{ label: 'value', value: 'value' }, { label: 'value2', value: 'value2' }] },
+    },
+  ];
+
+  const sourceFromBE = [
+    ...source,
+    {
+      boolean: { options: booleanOptions, current: '$and' },
+      field: { options: fieldOptions, current: 'languages' },
+      operator: { options: expect.any(Array), current: OPERATORS.IN },
+      value: { current: ['value', 'value2'] },
+    },
+  ];
+
   const initialValues = {
     $and: [
       { user_first_name: { $eq: 'value' } },
@@ -114,14 +121,13 @@ describe('mongoQueryToSource()', () => {
       { user_last_name: { $gt: 'value' } },
       { user_last_name: { $lt: 10 } },
       { user_last_name: { $gte: 'value' } },
-      { languages: { $in: ['value', 'value2'] } },
       { user_full_name: { $regex: 'abc' } },
-      { languages: { $nin: ['value', 'value2'] } },
       { user_id: { $nin: ['value', 'value2'] } },
       { user_id: { $in: ['value', 'value2'] } },
       { department_names: { $contains: 'value' } },
       { department_names: { $not_contains: 'value' } },
       { department_ids: { $empty: true } },
+      { languages: { $in: ['value', 'value2'] } },
     ],
   };
 
@@ -144,7 +150,7 @@ describe('mongoQueryToSource()', () => {
       return Array.isArray(currentValue) ? currentValue.map(({ value }) => value) : currentValue;
     };
 
-    expect(result).toEqual(source.map(v => ({
+    expect(result).toEqual(sourceFromBE.map(v => ({
       ...v,
       field: {
         ...v.field,
@@ -174,27 +180,9 @@ describe('mongoQueryToSource()', () => {
   });
 
   it('should convert from source to simple query format', () => {
-    const initial = {
-      $and: [
-        { user_first_name: { $eq: 'value' } },
-        { user_first_name: { $ne: 'value' } },
-        { user_last_name: { $gt: 'value' } },
-        { user_last_name: { $lt: 10 } },
-        { user_last_name: { $gte: 'value' } },
-        { languages: { $in: ['value', 'value2'] } },
-        { user_full_name: { $regex: 'abc' } },
-        { languages: { $nin: ['value', 'value2'] } },
-        { user_id: { $nin: ['value', 'value2'] } },
-        { user_id: { $in: ['value', 'value2'] } },
-        { department_names: { $contains: 'value' } },
-        { department_names: { $not_contains: 'value' } },
-        { department_ids: { $empty: true } },
-      ],
-    };
+    const result = sourceToMongoQuery(sourceFromUI);
 
-    const result = sourceToMongoQuery(source);
-
-    expect(result).toEqual(initial);
+    expect(result).toEqual(initialValues);
   });
 
   it('should convert from SINGLE source to simple query format', () => {


### PR DESCRIPTION
In scope of this PR was fixex formatting initial values for query-builder plugin, Now if we get a list of elements, it will be rendered in controls.  Ref: [UIPQB-86](https://folio-org.atlassian.net/browse/UIPQB-86)

Before: 
![image](https://github.com/folio-org/ui-plugin-query-builder/assets/86330150/f5228670-97e1-4e5e-9000-e77e3d444149)

After

![image](https://github.com/folio-org/ui-plugin-query-builder/assets/86330150/d415b0b8-3e78-4c80-939b-12af9aa27d39)
