### PR TITLE
[UIPQB-104] Use original fields when provided instead of re-selecting defaults

### DIFF
--- a/src/QueryBuilder/ResultViewer/ResultViewer.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.js
@@ -69,6 +69,7 @@ export const ResultViewer = ({
 
   // set visible by default columns once
   useViewerCallbacks({
+    visibleColumns,
     onSetDefaultColumns,
     defaultColumns,
     onSetDefaultVisibleColumns,

--- a/src/QueryBuilder/ResultViewer/ResultViewer.test.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.test.js
@@ -34,6 +34,11 @@ const renderResultViewer = (props) => (
 );
 
 describe('ResultViewer', () => {
+  beforeEach(() => {
+    setVisibleColumns.mockClear();
+    setColumns.mockClear();
+  });
+
   it('Should render accordion title', async () => {
     render(renderResultViewer());
 
@@ -63,14 +68,25 @@ describe('ResultViewer', () => {
   });
 
   describe('Initial and visible columns setters', () => {
-    it('should be called', async () => {
-      render(renderResultViewer());
+    it.each([[], undefined])('should call both when no initial fields are provided (recordColumns=%s)', async (visibleColumns) => {
+      render(renderResultViewer({ visibleColumns }));
 
       await waitFor(() => {
         expect(screen.queryByText('ui-plugin-query-builder.viewer.retrieving')).not.toBeInTheDocument();
 
         expect(setVisibleColumns).toHaveBeenCalled();
         expect(setColumns).toHaveBeenCalled();
+      });
+    });
+
+    it('should only call initial column setter when initial fields are provided', async () => {
+      render(renderResultViewer({ visibleColumns: ['user_id'] }));
+
+      await waitFor(() => {
+        expect(screen.queryByText('ui-plugin-query-builder.viewer.retrieving')).not.toBeInTheDocument();
+
+        expect(setColumns).toHaveBeenCalled();
+        expect(setVisibleColumns).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/hooks/useViewerCallbacks.js
+++ b/src/hooks/useViewerCallbacks.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 export const useViewerCallbacks = ({
+  visibleColumns,
   onSetDefaultColumns,
   defaultColumns,
   onSetDefaultVisibleColumns,
@@ -12,7 +13,10 @@ export const useViewerCallbacks = ({
   useEffect(() => {
     if (defaultColumns.length !== 0) {
       onSetDefaultColumns?.(defaultColumns);
-      onSetDefaultVisibleColumns?.(defaultVisibleColumns);
+      // only set visible columns if we're building a new query from scratch
+      if (visibleColumns.length === 0) {
+        onSetDefaultVisibleColumns?.(defaultVisibleColumns);
+      }
     }
   }, [currentRecordsCount]);
 

--- a/src/hooks/useViewerCallbacks.js
+++ b/src/hooks/useViewerCallbacks.js
@@ -14,7 +14,7 @@ export const useViewerCallbacks = ({
     if (defaultColumns.length !== 0) {
       onSetDefaultColumns?.(defaultColumns);
       // only set visible columns if we're building a new query from scratch
-      if (visibleColumns.length === 0) {
+      if (!visibleColumns?.length) {
         onSetDefaultVisibleColumns?.(defaultVisibleColumns);
       }
     }


### PR DESCRIPTION
When editing (or duplicating) a list, we want to keep the originally selected list of fields, rather than resetting to the defaults.