### PR TITLE
[UIPQB-90] Failure toast messages don't disappear automatically

### DIFF
--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
@@ -95,6 +95,7 @@ export const QueryBuilderModal = ({
       showCallout({
         message,
         type: 'error',
+        timeout: 6000, // from https://ux.folio.org/docs/guidelines/components/callout/
       });
       setIsQueryRetrieved(false);
     },


### PR DESCRIPTION
The [implementation of showCallout](https://github.com/folio-org/stripes-acq-components/blob/master/lib/hooks/useShowCallout/useShowCallout.js#L13) **deliberately does not follow** the [UX guidelines](https://ux.folio.org/docs/guidelines/components/callout/) ☹️ 