### PR TITLE
[UIPQB-107] Fix race condition when loading query using source values

### DIFF
--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -58,7 +58,7 @@ export const getTransformedValue = (val) => {
   if (Array.isArray(val)) {
     // when using multi-select - 'item.value'
     // for initial value case = just 'item'
-    return val.map((item) => item.value || item);
+    return val.map((item) => item?.value || item);
   }
 
   return val;

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -1,4 +1,4 @@
-import { isQueryValid, mongoQueryToSource, sourceToMongoQuery } from './query';
+import { getTransformedValue, isQueryValid, mongoQueryToSource, sourceToMongoQuery } from './query';
 import { booleanOptions } from './selectOptions';
 import { OPERATORS } from '../../../constants/operators';
 import { fieldOptions } from '../../../../test/jest/data/entityType';
@@ -276,5 +276,24 @@ describe('isQueryValid', () => {
     ];
 
     expect(isQueryValid(src)).toBe(true);
+  });
+});
+
+describe('getTransformedValue', () => {
+  it.each([
+    [undefined, undefined],
+    ['a', ['a']],
+    ['a ', ['a']],
+    [' a ', ['a']],
+    [' a , b   ', ['a', 'b']],
+    [[], []],
+    [['a', 'b'], ['a', 'b']],
+    [[{ value: 'a' }, { value: 'b' }], ['a', 'b']],
+    [[{ value: 'a' }, { value: 'b' }, 'c'], ['a', 'b', 'c']],
+    [[undefined, { value: 'b' }, 'c'], [undefined, 'b', 'c']],
+  ])('transforms %s to %s', (val, expected) => {
+    const actual = getTransformedValue(val);
+
+    expect(actual).toEqual(expected);
   });
 });

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
@@ -2,7 +2,7 @@ import { DATA_TYPES } from '../../../constants/dataTypes';
 import { OPERATORS } from '../../../constants/operators';
 
 export const getCommaSeparatedStr = (arr) => {
-  const str = arr?.map(el => `"${el.value}"`).join(',');
+  const str = arr?.map(el => `"${el?.value}"`).join(',');
 
   return `${str}`;
 };


### PR DESCRIPTION
It's possible for the values to be `undefined` when the column's source has not been loaded (such as when duplicating a list); this ensures our handling of these values can accommodate this.