### PR TITLE
[UIPQB-108] Only render the ResultViewer table once columns are loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (in progress)
 
+* [UIPQB-108](https://issues.folio.org/browse/UIPQB-108) Fix missing horizontal overflow in ResultViewer
+
 ## [1.1.3](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.3) (2024-04-02)
 
 * [UIPQB-86](https://folio-org.atlassian.net/browse/UIPQB-86) The IN operator is incorrectly rendered in the query builder when editing existing queries

--- a/src/QueryBuilder/ResultViewer/ResultViewer.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.js
@@ -165,7 +165,7 @@ export const ResultViewer = ({
       <>
         {renderHeader()}
         {renderAdditionalControls()}
-        {renderTable()}
+        {!!Object.keys(columnMapping).length && renderTable()}
       </>
     );
   };


### PR DESCRIPTION
# [Jira UIPQB-108](https://folio-org.atlassian.net/browse/UIPQB-108)

Real solution for https://github.com/folio-org/ui-lists/pull/129 / https://github.com/folio-org/ui-lists/pull/130.

Before `columnMapping` was calculated (pulled from local storage/api/etc), it would be an empty object, resulting in a MCL with either no columns or column names just being the field names (`id`, `address`, etc), which would not cause an overflow.  Loading that columnMapping in a frame/render cycle later would cause the names to appear, but the MCL's dimensions would not be recalculated.