### PR TITLE
UIPQB-113 Remove local QueryClientProvider from plugin-query-builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-plugin-query-builder
 
 ## (in progress)
+* [UIPQB-113](https://issues.folio.org/browse/UIPQB-113) Remove local QueryClientProvider from plugin-query-builder
 
 ## [1.1.4](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.4) (2024-04-02)
 

--- a/src/QueryBuilder/QueryBuilderPlugin.js
+++ b/src/QueryBuilder/QueryBuilderPlugin.js
@@ -1,5 +1,4 @@
 import PropTypes from 'prop-types';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ResultViewer } from './ResultViewer';
 import { QueryBuilder } from './QueryBuilder';
 
@@ -7,13 +6,11 @@ const VIEWER = 'viewer';
 const BUILDER = 'builder';
 
 export const QueryBuilderPlugin = ({ componentType, ...rest }) => {
-  const queryClient = new QueryClient();
-
   return (
-    <QueryClientProvider client={queryClient}>
+    <>
       {componentType === VIEWER && <ResultViewer {...rest} />}
       {componentType === BUILDER && <QueryBuilder {...rest} />}
-    </QueryClientProvider>
+    </>
   );
 };
 

--- a/src/hooks/useAsyncDataSource.js
+++ b/src/hooks/useAsyncDataSource.js
@@ -1,4 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
+
+import { useNamespace } from '@folio/stripes/core';
+
 import { getTableMetadata } from '../QueryBuilder/ResultViewer/helpers';
 import { useDebounce } from './useDebounce';
 import { useEntityType } from './useEntityType';
@@ -15,6 +18,7 @@ export const useAsyncDataSource = ({
   contentQueryKeys,
   forcedVisibleValues,
 }) => {
+  const [namespaceKey] = useNamespace({ key: QUERY_KEYS.QUERY_PLUGIN_CONTENT_DATA });
   const [debouncedOffset, debouncedLimit] = useDebounce([offset, limit], 200);
 
   const sharedOptions = { refetchOnWindowFocus: false, keepPreviousData: true };
@@ -31,7 +35,7 @@ export const useAsyncDataSource = ({
     refetch,
   } = useQuery(
     {
-      queryKey: [QUERY_KEYS.QUERY_PLUGIN_CONTENT_DATA, debouncedOffset, debouncedLimit, ...contentQueryKeys],
+      queryKey: [namespaceKey, debouncedOffset, debouncedLimit, ...contentQueryKeys],
       queryFn: () => contentDataSource({
         offset: debouncedOffset,
         limit: debouncedLimit,

--- a/src/hooks/useEntityType.js
+++ b/src/hooks/useEntityType.js
@@ -1,13 +1,18 @@
 import { useQuery } from '@tanstack/react-query';
+
+import { useNamespace } from '@folio/stripes/core';
+
 import { QUERY_KEYS } from '../constants/query';
 
 export const useEntityType = ({ entityTypeDataSource, sharedOptions = {} }) => {
+  const [namespaceKey] = useNamespace({ key: QUERY_KEYS.QUERY_PLUGIN_ENTITY_TYPE });
+
   const {
     data: entityType,
     isLoading: isEntityTypeLoading,
     isFetchedAfterMount: isContentTypeFetchedAfterMount,
   } = useQuery({
-    queryKey: [QUERY_KEYS.QUERY_PLUGIN_ENTITY_TYPE],
+    queryKey: [namespaceKey],
     queryFn: entityTypeDataSource,
     ...sharedOptions,
   });

--- a/src/hooks/useParamsDataSource.js
+++ b/src/hooks/useParamsDataSource.js
@@ -1,9 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
+import { useNamespace } from '@folio/stripes/core';
 import { QUERY_KEYS } from '../constants/query';
 
 export const useParamsDataSource = ({ source, searchValue, getParamsSource }) => {
+  const [namespaceKey] = useNamespace({ key: QUERY_KEYS.QUERY_PLUGIN_PARAMS_SOURCE });
+
   const { data, isLoading } = useQuery({
-    queryKey: [QUERY_KEYS.QUERY_PLUGIN_PARAMS_SOURCE, source, searchValue],
+    queryKey: [namespaceKey, source, searchValue],
     queryFn: () => getParamsSource({
       entityTypeId: source?.entityTypeId,
       columnName: source?.columnName,


### PR DESCRIPTION
- After this PR merged QueryClientProvider will be taken from stripes-core
- All query-kyes will be prefixed with namespace
Ref: [UIPQB-113](https://folio-org.atlassian.net/browse/UIPQB-113)