### PR TITLE
UIPQB-106: Remove restrictions of setting defaultVisibleColumns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@
 * [UIPQB-103](https://issues.folio.org/browse/UIPQB-103) Correct formatting of in and not in operators in query string.
 * [UIPQB-115](https://issues.folio.org/browse/UIPQB-115) Array type fields display strangely on the list details page, after adding them.
 * [UIPQB-117](https://folio-org.atlassian.net/browse/UIPQB-117)Add debounce for contentQueryKeys in useAsyncDataSource
+* [UIPQB-105](https://folio-org.atlassian.net/browse/UIPQB-106) The selected field doesn't display in the record table when we edit the query.
 
 ## [1.1.4](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.4) (2024-04-02)
 
 * [UIPQB-108](https://issues.folio.org/browse/UIPQB-108) Fix missing horizontal overflow in ResultViewer
-
+С
 ## [1.1.3](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.3) (2024-04-02)
 
 * [UIPQB-86](https://folio-org.atlassian.net/browse/UIPQB-86) The IN operator is incorrectly rendered in the query builder when editing existing queries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ## [1.1.4](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.4) (2024-04-02)
 
 * [UIPQB-108](https://issues.folio.org/browse/UIPQB-108) Fix missing horizontal overflow in ResultViewer
-С
+
 ## [1.1.3](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.3) (2024-04-02)
 
 * [UIPQB-86](https://folio-org.atlassian.net/browse/UIPQB-86) The IN operator is incorrectly rendered in the query builder when editing existing queries

--- a/src/QueryBuilder/ResultViewer/ResultViewer.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.js
@@ -68,9 +68,7 @@ export const ResultViewer = ({
   const isListLoading = isContentDataFetching || isContentDataLoading || isEntityTypeLoading || refreshInProgress;
   const currentRecordsCount = contentData?.length || 0;
 
-  // set visible by default columns once
   useViewerCallbacks({
-    visibleColumns,
     onSetDefaultColumns,
     defaultColumns,
     onSetDefaultVisibleColumns,

--- a/src/QueryBuilder/ResultViewer/ResultViewer.test.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.test.js
@@ -79,14 +79,14 @@ describe('ResultViewer', () => {
       });
     });
 
-    it('should only call initial column setter when initial fields are provided', async () => {
+    it('should call initial column setter when initial fields are changed', async () => {
       render(renderResultViewer({ visibleColumns: ['user_id'] }));
 
       await waitFor(() => {
         expect(screen.queryByText('ui-plugin-query-builder.viewer.retrieving')).not.toBeInTheDocument();
 
         expect(setColumns).toHaveBeenCalled();
-        expect(setVisibleColumns).not.toHaveBeenCalled();
+        expect(setVisibleColumns).toHaveBeenCalled();
       });
     });
   });

--- a/src/hooks/useEntityType.js
+++ b/src/hooks/useEntityType.js
@@ -10,6 +10,7 @@ export const useEntityType = ({ entityTypeDataSource, queryKey, sharedOptions = 
     queryKey: [queryKey],
     queryFn: entityTypeDataSource,
     ...sharedOptions,
+    refetchOnWindowFocus: false
   });
 
   return {

--- a/src/hooks/useEntityType.js
+++ b/src/hooks/useEntityType.js
@@ -10,7 +10,7 @@ export const useEntityType = ({ entityTypeDataSource, queryKey, sharedOptions = 
     queryKey: [queryKey],
     queryFn: entityTypeDataSource,
     ...sharedOptions,
-    refetchOnWindowFocus: false
+    refetchOnWindowFocus: false,
   });
 
   return {

--- a/src/hooks/useViewerCallbacks.js
+++ b/src/hooks/useViewerCallbacks.js
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 
 export const useViewerCallbacks = ({
-  visibleColumns,
   onSetDefaultColumns,
   defaultColumns,
   onSetDefaultVisibleColumns,
@@ -13,10 +12,8 @@ export const useViewerCallbacks = ({
   useEffect(() => {
     if (defaultColumns.length !== 0) {
       onSetDefaultColumns?.(defaultColumns);
-      // only set visible columns if we're building a new query from scratch
-      if (!visibleColumns?.length) {
-        onSetDefaultVisibleColumns?.(defaultVisibleColumns);
-      }
+
+      onSetDefaultVisibleColumns?.(defaultVisibleColumns);
     }
   }, [currentRecordsCount]);
 


### PR DESCRIPTION
FIx for [UIPQB-106](https://folio-org.atlassian.net/browse/UIPQB-106)

Remove restrictions of setting defaultVisibleColumns.

Problem: 
According to the [UIPQB-74](https://folio-org.atlassian.net/browse/UIPQB-74), non-default fields that are part of the query are automatically displayed as columns, but it works only for first fields

Root:
Because a non-default column adds to the defaultVisibleColumns, we set the defaultVisibleColumns only once. 

Solution: 
Our efficient solution is to remove the restriction and set defaultVisibleColumns after each test query.