### PR TITLE
UIPQB-116: Correct formatting of in and not in operators in query string when “Value“ column contains text box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [UIPQB-115](https://issues.folio.org/browse/UIPQB-115) Array type fields display strangely on the list details page, after adding them.
 * [UIPQB-117](https://folio-org.atlassian.net/browse/UIPQB-117)Add debounce for contentQueryKeys in useAsyncDataSource
 * [UIPQB-105](https://folio-org.atlassian.net/browse/UIPQB-106) The selected field doesn't display in the record table when we edit the query.
+* [UIPQB-116](https://folio-org.atlassian.net/browse/UIPQB-116) Correct formatting of in and not in operators in query string when “Value“ column contains text box
 
 ## [1.1.4](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.4) (2024-04-02)
 

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
@@ -7,9 +7,13 @@ export const getCommaSeparatedStr = (arr) => {
   return `(${str})`;
 };
 
-export const getQuotedStr = (value) => {
+export const getQuotedStr = (value, isInRelatedOperator = false) => {
   if (typeof value === 'boolean') {
     return JSON.stringify(value);
+  }
+
+  if (typeof value === 'string' && isInRelatedOperator) {
+    return `(${value.split(',').map(item => `"${item}"`).join(',')})`;
   }
 
   return value ? `"${value}"` : '';
@@ -27,23 +31,23 @@ export const valueBuilder = ({ value, field, operator, fieldOptions }) => {
   const isArray = Array.isArray(value);
   // add additional templates for dataTypes
   const valueMap = {
-    [DATA_TYPES.StringType]: () => (isArray ? getCommaSeparatedStr(value) : getQuotedStr(value)),
+    [DATA_TYPES.StringType]: () => (isArray ? getCommaSeparatedStr(value) : getQuotedStr(value, isInRelatedOperator)),
 
     [DATA_TYPES.IntegerType]: () => (isArray ? getCommaSeparatedStr(value) : value),
 
     [DATA_TYPES.NumberType]: () => (isArray ? getCommaSeparatedStr(value) : value),
 
-    [DATA_TYPES.RangedUUIDType]: () => getQuotedStr(value),
+    [DATA_TYPES.RangedUUIDType]: () => getQuotedStr(value, isInRelatedOperator),
 
-    [DATA_TYPES.ArrayType]: () => (isArray ? getCommaSeparatedStr(value) : getQuotedStr(value)),
+    [DATA_TYPES.ArrayType]: () => (isArray ? getCommaSeparatedStr(value) : getQuotedStr(value, isInRelatedOperator)),
 
-    [DATA_TYPES.EnumType]: () => (isArray ? getCommaSeparatedStr(value) : getQuotedStr(value)),
+    [DATA_TYPES.EnumType]: () => (isArray ? getCommaSeparatedStr(value) : getQuotedStr(value, isInRelatedOperator)),
 
-    [DATA_TYPES.BooleanType]: () => getQuotedStr(value),
+    [DATA_TYPES.BooleanType]: () => getQuotedStr(value, isInRelatedOperator),
 
-    [DATA_TYPES.ObjectType]: () => getQuotedStr(value),
+    [DATA_TYPES.ObjectType]: () => getQuotedStr(value, isInRelatedOperator),
 
-    [DATA_TYPES.DateType]: () => getQuotedStr(value),
+    [DATA_TYPES.DateType]: () => getQuotedStr(value, isInRelatedOperator),
 
     [DATA_TYPES.OpenUUIDType]: () => getFormattedUUID(value, isInRelatedOperator),
   };

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.test.js
@@ -58,7 +58,7 @@ describe('valueBuilder', () => {
     const field = 'user_patron_group';
     const operator = OPERATORS.IN;
 
-    expect(valueBuilder({ value, field, operator, fieldOptions })).toBe(getQuotedStr(value));
+    expect(valueBuilder({ value, field, operator, fieldOptions })).toBe(getQuotedStr(value, true));
   });
 
   test('should return an empty string if value is falsy for DateType', () => {
@@ -112,5 +112,13 @@ describe('valueBuilder', () => {
     const operator = OPERATORS.EQUAL;
 
     expect(valueBuilder({ value, field, operator, fieldOptions })).toBe(getQuotedStr(value));
+  });
+
+  test('should return a string enclosed in double quotes for String with in operator', () => {
+    const value = '123,456,789';
+    const field = 'item_holdingsrecord_id';
+    const operator = OPERATORS.IN;
+
+    expect(valueBuilder({ value, field, operator, fieldOptions })).toBe(getQuotedStr(value, true));
   });
 });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-116
We fixed formatting for value with `IN` and `NOT_IN` operators

https://github.com/folio-org/ui-plugin-query-builder/assets/72550466/87b09666-52ff-48b0-9487-9bdff036743d

