### PR TITLE
UIPQB-112: Query builder: Accessibility: Not equal operator value is not read by screenreader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [UIPQB-115](https://issues.folio.org/browse/UIPQB-115) Array type fields display strangely on the list details page, after adding them.
 * [UIPQB-117](https://folio-org.atlassian.net/browse/UIPQB-117)Add debounce for contentQueryKeys in useAsyncDataSource
 * [UIPQB-105](https://folio-org.atlassian.net/browse/UIPQB-106) The selected field doesn't display in the record table when we edit the query.
+* [UIPQB-112](https://folio-org.atlassian.net/browse/UIPQB-112) Query builder: Accessibility: Not equal operator value is not read by screenreader
 
 ## [1.1.4](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.4) (2024-04-02)
 

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -1,6 +1,6 @@
 import { FormattedMessage } from 'react-intl';
 import { DATA_TYPES } from '../../../constants/dataTypes';
-import { BOOLEAN_OPERATORS, OPERATORS } from '../../../constants/operators';
+import { BOOLEAN_OPERATORS, OPERATORS, OPERATORS_LABELS } from '../../../constants/operators';
 import { COLUMN_KEYS } from '../../../constants/columnKeys';
 
 const getOperatorsWithPlaceholder = (options, intl) => {
@@ -15,8 +15,8 @@ const getOperatorsWithPlaceholder = (options, intl) => {
 };
 
 const baseLogicalOperators = () => [
-  { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-  { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+  { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+  { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
   { label: OPERATORS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
   { label: OPERATORS.LESS_THAN, value: OPERATORS.LESS_THAN },
 ];
@@ -29,16 +29,16 @@ const extendedLogicalOperators = () => [
 ];
 
 const UUIDOperators = () => [
-  { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-  { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+  { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+  { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
   { label: OPERATORS.IN, value: OPERATORS.IN },
   { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
   { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
 ];
 
 const ArrayOperators = () => [
-  { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-  { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+  { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+  { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
   { label: OPERATORS.IN, value: OPERATORS.IN },
   { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
   { label: OPERATORS.CONTAINS, value: OPERATORS.CONTAINS },
@@ -52,8 +52,8 @@ export const getFilledValues = (options) => {
 
 const stringOperators = (hasSourceOrValues) => {
   return [
-    { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-    { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+    { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+    { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
     ...(hasSourceOrValues ? [
       { label: OPERATORS.IN, value: OPERATORS.IN },
       { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
@@ -66,8 +66,8 @@ const stringOperators = (hasSourceOrValues) => {
 };
 
 const booleanOperators = () => [
-  { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-  { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+  { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+  { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
   { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
 ];
 

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -17,33 +17,33 @@ const getOperatorsWithPlaceholder = (options, intl) => {
 const baseLogicalOperators = () => [
   { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
   { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-  { label: OPERATORS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
-  { label: OPERATORS.LESS_THAN, value: OPERATORS.LESS_THAN },
+  { label: OPERATORS_LABELS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
+  { label: OPERATORS_LABELS.LESS_THAN, value: OPERATORS.LESS_THAN },
 ];
 
 const extendedLogicalOperators = () => [
   ...baseLogicalOperators(),
-  { label: OPERATORS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
-  { label: OPERATORS.LESS_THAN_OR_EQUAL, value: OPERATORS.LESS_THAN_OR_EQUAL },
-  { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+  { label: OPERATORS_LABELS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
+  { label: OPERATORS_LABELS.LESS_THAN_OR_EQUAL, value: OPERATORS.LESS_THAN_OR_EQUAL },
+  { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
 ];
 
 const UUIDOperators = () => [
   { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
   { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-  { label: OPERATORS.IN, value: OPERATORS.IN },
-  { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
-  { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+  { label: OPERATORS_LABELS.IN, value: OPERATORS.IN },
+  { label: OPERATORS_LABELS.NOT_IN, value: OPERATORS.NOT_IN },
+  { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
 ];
 
 const ArrayOperators = () => [
   { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
   { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-  { label: OPERATORS.IN, value: OPERATORS.IN },
-  { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
-  { label: OPERATORS.CONTAINS, value: OPERATORS.CONTAINS },
-  { label: OPERATORS.NOT_CONTAINS, value: OPERATORS.NOT_CONTAINS },
-  { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+  { label: OPERATORS_LABELS.IN, value: OPERATORS.IN },
+  { label: OPERATORS_LABELS.NOT_IN, value: OPERATORS.NOT_IN },
+  { label: OPERATORS_LABELS.CONTAINS, value: OPERATORS.CONTAINS },
+  { label: OPERATORS_LABELS.NOT_CONTAINS, value: OPERATORS.NOT_CONTAINS },
+  { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
 ];
 
 export const getFilledValues = (options) => {
@@ -55,20 +55,20 @@ const stringOperators = (hasSourceOrValues) => {
     { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
     { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
     ...(hasSourceOrValues ? [
-      { label: OPERATORS.IN, value: OPERATORS.IN },
-      { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
+      { label: OPERATORS_LABELS.IN, value: OPERATORS.IN },
+      { label: OPERATORS_LABELS.NOT_IN, value: OPERATORS.NOT_IN },
     ] : [
-      { label: OPERATORS.CONTAINS, value: OPERATORS.CONTAINS },
-      { label: OPERATORS.STARTS_WITH, value: OPERATORS.STARTS_WITH },
+      { label: OPERATORS_LABELS.CONTAINS, value: OPERATORS.CONTAINS },
+      { label: OPERATORS_LABELS.STARTS_WITH, value: OPERATORS.STARTS_WITH },
     ]),
-    { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+    { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
   ];
 };
 
 const booleanOperators = () => [
   { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
   { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-  { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+  { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
 ];
 
 export const getOperatorOptions = ({

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -102,9 +102,9 @@ describe('select options', () => {
         operators: [
           { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
           { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-          { label: OPERATORS.CONTAINS, value: OPERATORS.CONTAINS },
-          { label: OPERATORS.STARTS_WITH, value: OPERATORS.STARTS_WITH },
-          { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+          { label: OPERATORS_LABELS.CONTAINS, value: OPERATORS.CONTAINS },
+          { label: OPERATORS_LABELS.STARTS_WITH, value: OPERATORS.STARTS_WITH },
+          { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
         ],
       });
     });
@@ -121,9 +121,9 @@ describe('select options', () => {
         operators: [
           { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
           { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-          { label: OPERATORS.IN, value: OPERATORS.IN },
-          { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
-          { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+          { label: OPERATORS_LABELS.IN, value: OPERATORS.IN },
+          { label: OPERATORS_LABELS.NOT_IN, value: OPERATORS.NOT_IN },
+          { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
         ],
       });
     });
@@ -140,11 +140,11 @@ describe('select options', () => {
         operators: [
           { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
           { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-          { label: OPERATORS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
-          { label: OPERATORS.LESS_THAN, value: OPERATORS.LESS_THAN },
-          { label: OPERATORS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
-          { label: OPERATORS.LESS_THAN_OR_EQUAL, value: OPERATORS.LESS_THAN_OR_EQUAL },
-          { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+          { label: OPERATORS_LABELS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
+          { label: OPERATORS_LABELS.LESS_THAN, value: OPERATORS.LESS_THAN },
+          { label: OPERATORS_LABELS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
+          { label: OPERATORS_LABELS.LESS_THAN_OR_EQUAL, value: OPERATORS.LESS_THAN_OR_EQUAL },
+          { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
         ],
       });
     });
@@ -161,11 +161,11 @@ describe('select options', () => {
         operators: [
           { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
           { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-          { label: OPERATORS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
-          { label: OPERATORS.LESS_THAN, value: OPERATORS.LESS_THAN },
-          { label: OPERATORS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
-          { label: OPERATORS.LESS_THAN_OR_EQUAL, value: OPERATORS.LESS_THAN_OR_EQUAL },
-          { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+          { label: OPERATORS_LABELS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
+          { label: OPERATORS_LABELS.LESS_THAN, value: OPERATORS.LESS_THAN },
+          { label: OPERATORS_LABELS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
+          { label: OPERATORS_LABELS.LESS_THAN_OR_EQUAL, value: OPERATORS.LESS_THAN_OR_EQUAL },
+          { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
         ],
       });
     });
@@ -182,7 +182,7 @@ describe('select options', () => {
         operators: [
           { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
           { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-          { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+          { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
         ],
       });
     });
@@ -199,9 +199,9 @@ describe('select options', () => {
         operators: [
           { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
           { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-          { label: OPERATORS.IN, value: OPERATORS.IN },
-          { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
-          { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+          { label: OPERATORS_LABELS.IN, value: OPERATORS.IN },
+          { label: OPERATORS_LABELS.NOT_IN, value: OPERATORS.NOT_IN },
+          { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
         ],
       });
     });
@@ -218,11 +218,11 @@ describe('select options', () => {
         operators: [
           { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
           { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-          { label: OPERATORS.IN, value: OPERATORS.IN },
-          { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
-          { label: OPERATORS.CONTAINS, value: OPERATORS.CONTAINS },
-          { label: OPERATORS.NOT_CONTAINS, value: OPERATORS.NOT_CONTAINS },
-          { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+          { label: OPERATORS_LABELS.IN, value: OPERATORS.IN },
+          { label: OPERATORS_LABELS.NOT_IN, value: OPERATORS.NOT_IN },
+          { label: OPERATORS_LABELS.CONTAINS, value: OPERATORS.CONTAINS },
+          { label: OPERATORS_LABELS.NOT_CONTAINS, value: OPERATORS.NOT_CONTAINS },
+          { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
         ],
       });
     });
@@ -239,9 +239,9 @@ describe('select options', () => {
         operators: [
           { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
           { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-          { label: OPERATORS.IN, value: OPERATORS.IN },
-          { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
-          { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+          { label: OPERATORS_LABELS.IN, value: OPERATORS.IN },
+          { label: OPERATORS_LABELS.NOT_IN, value: OPERATORS.NOT_IN },
+          { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
         ],
       });
     });
@@ -258,11 +258,11 @@ describe('select options', () => {
         operators: [
           { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
           { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
-          { label: OPERATORS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
-          { label: OPERATORS.LESS_THAN, value: OPERATORS.LESS_THAN },
-          { label: OPERATORS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
-          { label: OPERATORS.LESS_THAN_OR_EQUAL, value: OPERATORS.LESS_THAN_OR_EQUAL },
-          { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
+          { label: OPERATORS_LABELS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
+          { label: OPERATORS_LABELS.LESS_THAN, value: OPERATORS.LESS_THAN },
+          { label: OPERATORS_LABELS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
+          { label: OPERATORS_LABELS.LESS_THAN_OR_EQUAL, value: OPERATORS.LESS_THAN_OR_EQUAL },
+          { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
         ],
       });
     });

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -1,6 +1,6 @@
 import { getFieldOptions, getOperatorOptions } from './selectOptions';
 import { DATA_TYPES } from '../../../constants/dataTypes';
-import { OPERATORS } from '../../../constants/operators';
+import { OPERATORS, OPERATORS_LABELS } from '../../../constants/operators';
 
 const entityType = {
   columns: [
@@ -100,8 +100,8 @@ describe('select options', () => {
       expectFn({
         options,
         operators: [
-          { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-          { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
           { label: OPERATORS.CONTAINS, value: OPERATORS.CONTAINS },
           { label: OPERATORS.STARTS_WITH, value: OPERATORS.STARTS_WITH },
           { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
@@ -119,8 +119,8 @@ describe('select options', () => {
       expectFn({
         options,
         operators: [
-          { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-          { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
           { label: OPERATORS.IN, value: OPERATORS.IN },
           { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
           { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
@@ -138,8 +138,8 @@ describe('select options', () => {
       expectFn({
         options,
         operators: [
-          { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-          { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
           { label: OPERATORS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
           { label: OPERATORS.LESS_THAN, value: OPERATORS.LESS_THAN },
           { label: OPERATORS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
@@ -159,8 +159,8 @@ describe('select options', () => {
       expectFn({
         options,
         operators: [
-          { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-          { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
           { label: OPERATORS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
           { label: OPERATORS.LESS_THAN, value: OPERATORS.LESS_THAN },
           { label: OPERATORS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
@@ -180,8 +180,8 @@ describe('select options', () => {
       expectFn({
         options,
         operators: [
-          { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-          { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
           { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
         ],
       });
@@ -197,8 +197,8 @@ describe('select options', () => {
       expectFn({
         options,
         operators: [
-          { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-          { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
           { label: OPERATORS.IN, value: OPERATORS.IN },
           { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
           { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
@@ -216,8 +216,8 @@ describe('select options', () => {
       expectFn({
         options,
         operators: [
-          { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-          { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
           { label: OPERATORS.IN, value: OPERATORS.IN },
           { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
           { label: OPERATORS.CONTAINS, value: OPERATORS.CONTAINS },
@@ -237,8 +237,8 @@ describe('select options', () => {
       expectFn({
         options,
         operators: [
-          { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-          { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
           { label: OPERATORS.IN, value: OPERATORS.IN },
           { label: OPERATORS.NOT_IN, value: OPERATORS.NOT_IN },
           { label: OPERATORS.EMPTY, value: OPERATORS.EMPTY },
@@ -256,8 +256,8 @@ describe('select options', () => {
       expectFn({
         options,
         operators: [
-          { label: OPERATORS.EQUAL, value: OPERATORS.EQUAL },
-          { label: OPERATORS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
           { label: OPERATORS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
           { label: OPERATORS.LESS_THAN, value: OPERATORS.LESS_THAN },
           { label: OPERATORS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },

--- a/src/constants/operators.js
+++ b/src/constants/operators.js
@@ -20,3 +20,8 @@ export const BOOLEAN_OPERATORS = {
 export const BOOLEAN_OPERATORS_MAP = {
   [BOOLEAN_OPERATORS.AND]: 'AND',
 };
+
+export const OPERATORS_LABELS = {
+  EQUAL: 'equals',
+  NOT_EQUAL: 'not equal to',
+};

--- a/src/constants/operators.js
+++ b/src/constants/operators.js
@@ -24,4 +24,14 @@ export const BOOLEAN_OPERATORS_MAP = {
 export const OPERATORS_LABELS = {
   EQUAL: 'equals',
   NOT_EQUAL: 'not equal to',
+  GREATER_THAN: '>',
+  LESS_THAN: '<',
+  GREATER_THAN_OR_EQUAL: '>=',
+  LESS_THAN_OR_EQUAL: '<=',
+  IN: 'in',
+  NOT_IN: 'not in',
+  CONTAINS: 'contains',
+  NOT_CONTAINS: 'not contains',
+  STARTS_WITH: 'starts with',
+  EMPTY: ' is null/empty',
 };


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-112
Here we changed label for `equals` and `not equals` operators