### PR TITLE
[UIPQB-118] Support stringUUIDType

### DIFF
--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
@@ -176,6 +176,9 @@ export const DataTypeInput = ({
     case DATA_TYPES.RangedUUIDType:
       return textControl({ testId: 'data-input-text-rangedUUIDType' });
 
+    case DATA_TYPES.StringUUIDType:
+      return textControl({ testId: 'data-input-text-stringUUIDType' });
+
     case DATA_TYPES.DateType:
       return datePickerControl();
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.test.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.test.js
@@ -75,6 +75,11 @@ const arr = [
     componentTestId: 'data-input-text-rangedUUIDType',
   },
   {
+    dataType: DATA_TYPES.StringUUIDType,
+    operator: OPERATORS.EQUAL,
+    componentTestId: 'data-input-text-stringUUIDType',
+  },
+  {
     dataType: DATA_TYPES.OpenUUIDType,
     operator: OPERATORS.IN,
     componentTestId: 'data-input-textarea',

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -81,14 +81,11 @@ export const getOperatorOptions = ({
       return getOperatorsWithPlaceholder(stringOperators(hasSourceOrValues), intl);
 
     case DATA_TYPES.RangedUUIDType:
-      return getOperatorsWithPlaceholder(UUIDOperators(), intl);
-
     case DATA_TYPES.OpenUUIDType:
+    case DATA_TYPES.StringUUIDType:
       return getOperatorsWithPlaceholder(UUIDOperators(), intl);
 
     case DATA_TYPES.IntegerType:
-      return getOperatorsWithPlaceholder(extendedLogicalOperators(), intl);
-
     case DATA_TYPES.NumberType:
       return getOperatorsWithPlaceholder(extendedLogicalOperators(), intl);
 

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -128,6 +128,25 @@ describe('select options', () => {
       });
     });
 
+    it('should return UUID operators with placeholder for string UUID type', () => {
+      const options = getOperatorOptions({
+        dataType: DATA_TYPES.StringUUIDType,
+        hasSourceOrValues: true,
+        intl: intlMock,
+      });
+
+      expectFn({
+        options,
+        operators: [
+          { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS_LABELS.IN, value: OPERATORS.IN },
+          { label: OPERATORS_LABELS.NOT_IN, value: OPERATORS.NOT_IN },
+          { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
+        ],
+      });
+    });
+
     it('should return extended logical operators with placeholder for integer type', () => {
       const options = getOperatorOptions({
         dataType: DATA_TYPES.IntegerType,

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
@@ -50,6 +50,8 @@ export const valueBuilder = ({ value, field, operator, fieldOptions }) => {
     [DATA_TYPES.DateType]: () => getQuotedStr(value, isInRelatedOperator),
 
     [DATA_TYPES.OpenUUIDType]: () => getFormattedUUID(value, isInRelatedOperator),
+
+    [DATA_TYPES.StringUUIDType]: () => getFormattedUUID(value, isInRelatedOperator),
   };
 
   return valueMap[dataType]?.();

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.test.js
@@ -106,6 +106,14 @@ describe('valueBuilder', () => {
     expect(valueBuilder({ value, field, operator, fieldOptions })).toBe(getQuotedStr(value));
   });
 
+  test('should return a string enclosed in double quotes for StringUUIDType if operator is not IN or NOT_IN', () => {
+    const value = 'val';
+    const field = 'string_uuid';
+    const operator = OPERATORS.EQUAL;
+
+    expect(valueBuilder({ value, field, operator, fieldOptions })).toBe(getQuotedStr(value));
+  });
+
   test('should return a string enclosed in double quotes for EnumType if value is a string', () => {
     const value = 'active';
     const field = 'status';

--- a/src/constants/dataTypes.js
+++ b/src/constants/dataTypes.js
@@ -2,6 +2,7 @@ export const DATA_TYPES = {
   StringType: 'stringType',
   RangedUUIDType: 'rangedUUIDType',
   OpenUUIDType: 'openUUIDType',
+  StringUUIDType: 'stringUUIDType',
   NumberType: 'numberType',
   IntegerType: 'integerType',
   DateType: 'dateType',

--- a/test/jest/data/entityType.js
+++ b/test/jest/data/entityType.js
@@ -365,6 +365,15 @@ export const entityType = {
       'labelAlias': 'Not queryable',
       'visibleByDefault': false,
     },
+    {
+      'name': 'string_uuid',
+      'queryable': false,
+      'dataType': {
+        'dataType': 'stringUUIDType',
+      },
+      'labelAlias': 'UUID, but string',
+      'visibleByDefault': false,
+    },
   ],
   'defaultSort': [
     {


### PR DESCRIPTION
# [UIPQB-118](https://folio-org.atlassian.net/browse/UIPQB-118)

Adds support for `stringUUIDType`, using the same controls as existing UUID structures.