### PR TITLE
[UIPQB-130] Add transformation to number

### DIFF
--- a/src/QueryBuilder/QueryBuilder/TestQuery/TestQuery.js
+++ b/src/QueryBuilder/QueryBuilder/TestQuery/TestQuery.js
@@ -112,7 +112,7 @@ export const TestQuery = ({
     onSetDefaultVisibleColumns(values);
   };
 
-  const renderDropdown = ({ currentRecordsCount }) => !!currentRecordsCount && (
+  const renderDropdown = ({ currentRecordsCount }) => !!Number(currentRecordsCount) && (
     <ColumnsDropdown
       columns={columns}
       visibleColumns={visibleColumns}


### PR DESCRIPTION
Fix for [UIPQB-130](https://folio-org.atlassian.net/browse/UIPQB-130)

Root cause: currentRecordsCount was passed as a string so check !!'0' is true. Because of that, we rendered dropdown even if we didn't have results
