### PR TITLE
[UIPQB-134] Fix prop-type for ViewerHeadline

### DIFF
--- a/src/QueryBuilder/QueryBuilder/TestQuery/TestQuery.js
+++ b/src/QueryBuilder/QueryBuilder/TestQuery/TestQuery.js
@@ -120,7 +120,7 @@ export const TestQuery = ({
     />
   );
 
-  const renderHeadline = ({ totalRecords: total = 0, currentRecordsCount = 0, defaultLimit, status }) => {
+  const renderHeadline = ({ totalRecords: total = '0', currentRecordsCount = '0', defaultLimit, status }) => {
     const isInProgress = status === QUERY_DETAILS_STATUSES.IN_PROGRESS && !recordsLimitExceeded;
     const limit = currentRecordsCount < defaultLimit ? currentRecordsCount : defaultLimit;
 

--- a/src/QueryBuilder/QueryBuilder/TestQuery/ViewerHeadline/ViewerHeadline.js
+++ b/src/QueryBuilder/QueryBuilder/TestQuery/ViewerHeadline/ViewerHeadline.js
@@ -7,12 +7,12 @@ import css from '../../../QueryBuilder.css';
 export const ViewerHeadline = memo(({ limit, total, isInProgress }) => {
   return (
     <>
-      {Number(total) === 0 ?
+      {Number(total) === 0 ? (
         <FormattedMessage
           id="ui-plugin-query-builder.modal.preview.title.empty"
           values={{ total }}
         />
-        :
+      ) : (
         <FormattedMessage
           id="ui-plugin-query-builder.modal.preview.title"
           values={{
@@ -20,8 +20,7 @@ export const ViewerHeadline = memo(({ limit, total, isInProgress }) => {
             limit,
           }}
         />
-            }
-      {' '}
+      )}{' '}
       {isInProgress && (
         <span className={css.AccordionHeaderLoading}>
           <FormattedMessage id="ui-plugin-query-builder.modal.preview.countingInProgress" />
@@ -33,7 +32,7 @@ export const ViewerHeadline = memo(({ limit, total, isInProgress }) => {
 });
 
 ViewerHeadline.propTypes = {
-  limit: PropTypes.number,
+  limit: PropTypes.string,
   total: PropTypes.number,
   isInProgress: PropTypes.bool,
 };


### PR DESCRIPTION
# [Jira UIPQB-134](https://folio-org.atlassian.net/browse/UIPQB-134)

Cleans up an incorrect prop-type that seems to have been introduced in UIPQB-34: https://github.com/folio-org/ui-plugin-query-builder/commit/b4b935310b0fdafc23a50aa7f081debc0e536494#diff-b125605a4c0eb21cc5cc4b43dbfb3164470971c6024b04292b15e28064018589R89-R101. That commit localized the numbers, turning them into strings, but the prop-type was never updated.

If only we had typescript :(