### PR TITLE
[UIPQB-126] Update date format to UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@
 * [UIPQB-79](https://folio-org.atlassian.net/browse/UIPQB-79) Update available operators for arrays
 * [UIPQB-131](https://folio-org.atlassian.net/browse/UIPQB-131) Columns and empty area display in the list details page, when we refresh the page 1st time or duplicate the list
 * [UIPQB-132](https://folio-org.atlassian.net/browse/UIPQB-132) Save not empty previews results and show it in test query
-
+* [UIPQB-126](https://folio-org.atlassian.net/browse/UIPQB-126) Update date format in requests to UTC
+  
 ## [1.1.4](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.4) (2024-04-02)
 
 * [UIPQB-108](https://issues.folio.org/browse/UIPQB-108) Fix missing horizontal overflow in ResultViewer

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
@@ -11,7 +11,7 @@ import { DATA_TYPES } from '../../../../constants/dataTypes';
 import { COLUMN_KEYS } from '../../../../constants/columnKeys';
 import { OPERATORS } from '../../../../constants/operators';
 import { SelectionContainer } from '../SelectionContainer/SelectionContainer';
-import { ISO_FORMAT } from '../../helpers/timeUtils';
+import { UTC_FORMAT } from '../../helpers/timeUtils';
 
 import css from '../../../QueryBuilder.css';
 import { staticBooleanOptions } from '../../helpers/selectOptions';
@@ -95,7 +95,7 @@ export const DataTypeInput = ({
   const datePickerControl = () => (
     <Datepicker
       data-testid="data-input-dateType"
-      backendDateStandard={ISO_FORMAT}
+      backendDateStandard={UTC_FORMAT}
       onChange={(e, value, formattedValue) => {
         onChange(formattedValue, index, COLUMN_KEYS.VALUE);
       }}

--- a/src/QueryBuilder/QueryBuilder/helpers/timeUtils.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/timeUtils.js
@@ -1,1 +1,2 @@
 export const ISO_FORMAT = 'YYYY-MM-DD';
+export const UTC_FORMAT = 'YYYY-MM-DDTHH:MM:SS';


### PR DESCRIPTION
Implementation of [UIPQB-126](https://folio-org.atlassian.net/browse/UIPQB-126)

Update date format in requests to UTC

Old format: 'YYYY-MM-DD'
<img width="473" alt="Screenshot 2024-09-26 at 15 09 35" src="https://github.com/user-attachments/assets/a83dcb75-01c0-48d5-bec8-13545b05139c">


New format: 'YYYY-MM-DDTHH:MM:SS'
<img width="508" alt="Screenshot 2024-09-26 at 15 07 32" src="https://github.com/user-attachments/assets/1aaaf76d-caea-4749-868d-90cb8607f8f8">
