### PR TITLE
UIPQB-133: [QB] Opens "Something went wrong" page when we try to search for the field name which contains brackets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [UIPQB-132](https://folio-org.atlassian.net/browse/UIPQB-132) Save not empty previews results and show it in test query
 * [UIPQB-126](https://folio-org.atlassian.net/browse/UIPQB-126) Update date format in requests to UTC
 * [UIPQB-125](https://folio-org.atlassian.net/browse/UIPQB-125) Add support for FQM _version
+* [UIPQB-133](https://folio-org.atlassian.net/browse/UIPQB-133) [QB] Opens "Something went wrong" page when we try to search for the field name which contains brackets
   
 ## [1.1.4](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.4) (2024-04-02)
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
@@ -39,7 +39,8 @@ export const RepeatableFields = ({ source, setSource, getParamsSource, columns }
   };
 
   const onFilter = (value, dataOptions) => {
-    return dataOptions.filter(option => new RegExp(value, 'i').test(option.label));
+    const escapedValue = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return dataOptions.filter(option => new RegExp(escapedValue, 'i').test(option.label));
   };
 
   const handleChange = (value, index, fieldName) => {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-133

Here we added fix for the `filter` function to prevent app from crashing if we use special symbols in the search filter