### PR TITLE
UIPQB-102: The 'Organization accounting code' value contains incorrect '\'(backslash) in the query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@
 * [UIPQB-137](https://folio-org.atlassian.net/browse/UIPQB-137) Spell out query builder operators
 * [UIPQB-140](https://folio-org.atlassian.net/browse/UIPQB-140) fix preview to display records when result is more than 100
 * [UIPQB-143](https://folio-org.atlassian.net/browse/UIPQB-143) Translate language codes to languages in the ResultsViewer
+* [UIPQB-102](https://folio-org.atlassian.net/browse/UIPQB-102)The 'Organization accounting code' value contains incorrect '\'(backslash) in the query.
   
+
 ## [1.1.4](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.4) (2024-04-02)
 
 * [UIPQB-108](https://issues.folio.org/browse/UIPQB-108) Fix missing horizontal overflow in ResultViewer

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -64,7 +64,7 @@ export const getTransformedValue = (val) => {
 };
 
 const escapeRegex = (value) => {
-  const escapedValue = value?.toString().replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+  const escapedValue = value?.toString().replace(/[/^$*+?.()|[\]{}]/g, '\\$&');
 
   return `${escapedValue}`;
 };


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-102

Here we removed the incarnation for `slash` since it's  used in query search.

https://github.com/user-attachments/assets/e38c7b8f-5f09-4e68-a449-6037b1298583

