### PR TITLE
UIPQB-138: Fix layout for the DatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [UIPQB-140](https://folio-org.atlassian.net/browse/UIPQB-140) fix preview to display records when result is more than 100
 * [UIPQB-143](https://folio-org.atlassian.net/browse/UIPQB-143) Translate language codes to languages in the ResultsViewer
 * Bump "@folio/stripes-acq-components" version to v6.0.0
+* [UIPQB-138](https://folio-org.atlassian.net/browse/UIPQB-138) [QB] It's not possible to select the current date from the DatePicker.
   
 ## [1.1.4](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.4) (2024-04-02)
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/QueryBuilderModal.js
@@ -7,6 +7,7 @@ import {
   Headline,
   Loading,
   Row,
+  StripesOverlayWrapper,
 } from '@folio/stripes/components';
 import { useShowCallout } from '@folio/stripes-acq-components';
 import { useQueryClient } from 'react-query';
@@ -235,7 +236,7 @@ export const QueryBuilderModal = ({
           <Loading size="large" />
         </Row>
       ) : (
-        <>
+        <StripesOverlayWrapper>
           <RepeatableFields
             source={source}
             setSource={handleSetSource}
@@ -267,7 +268,7 @@ export const QueryBuilderModal = ({
             recordsLimit={recordsLimit}
             additionalControls={additionalControls}
           />
-        </>
+        </StripesOverlayWrapper>
       )}
 
     </Modal>

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
@@ -166,6 +166,7 @@ export const RepeatableFields = ({ source, setSource, getParamsSource, columns }
                     onChange={handleChange}
                     data-testid={`input-value-${index}`}
                     aria-label={`input-value-${index}`}
+                    usePortal
                   />
                 )}
               </Col>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-138

Here we added `StripesOverlayWrapper` for `RepeatableField`.

https://github.com/user-attachments/assets/9782a1d6-65f7-4387-88e8-b67c907c79d6

update after `usePortal` prop 

https://github.com/user-attachments/assets/2ea40cec-9e63-4d5c-8193-3ae8666b441f


