### PR TITLE
UIPQB-147: Filtering of available values is case sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * [UIPQB-140](https://folio-org.atlassian.net/browse/UIPQB-140) fix preview to display records when result is more than 100
 * [UIPQB-143](https://folio-org.atlassian.net/browse/UIPQB-143) Translate language codes to languages in the ResultsViewer
 * Bump "@folio/stripes-acq-components" version to v6.0.0
+* [UIPQB-147](https://folio-org.atlassian.net/browse/UIPQB-147) Filtering of available values is case sensitive.
   
 ## [1.1.4](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.1.4) (2024-04-02)
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.js
@@ -33,16 +33,19 @@ export const SelectionContainer = ({
   const { data } = useParamsDataSource({ source, searchValue, getParamsSource });
 
   const filterOptions = (filterText, list) => {
-    // escape special characters in filter text, so they won't be interpreted by RegExp
-    const escapedFilterText = filterText?.replace(/[#-.]|[[-^]|[?|{}]/g, '\\$&');
+    const lowerCaseFilterText = filterText?.toLowerCase() || '';
 
-    setSearchValue(filterText);
+    setSearchValue(lowerCaseFilterText);
 
-    const filterRegExp = new RegExp(`${escapedFilterText}`, 'i');
-    const renderedItems = filterText ? list?.filter(item => item.label.search(filterRegExp) !== -1)
-      :
-      list;
-    const exactMatch = filterText ? (renderedItems.filter(item => item.label === filterText).length === 1) : false;
+    // filtering based on list label
+    const renderedItems = lowerCaseFilterText
+      ? list.filter(item => item.label.toLowerCase().includes(lowerCaseFilterText))
+      : list;
+
+    // check for exact math using non-case sensitive
+    const exactMatch = lowerCaseFilterText
+      ? renderedItems.some(item => item.label.toLowerCase() === lowerCaseFilterText)
+      : false;
 
     return { renderedItems, exactMatch };
   };


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-147

Here is the fix for filtering values in the `value column` ( case non-sensitive )


https://github.com/user-attachments/assets/8692d8c8-5bc1-47a9-ba71-51be4815ca64

