### PR TITLE
UIPQB-102 Remove backslashes from fqm query initial value (follow up)

### DIFF
--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -64,7 +64,15 @@ export const getTransformedValue = (val) => {
 };
 
 const escapeRegex = (value) => {
-  return value?.toString().replace(/[/^$*+?.()|[\]{}]/g, '\\$&');
+  return value?.toString().replace(/[/\-\\^$*+?.()|[\]{}]/g, '\\$&');
+};
+
+const unescapeRegex = (value) => {
+  // remove leading '^' and trailing '/' from regex
+  const cleanerRegex = /((^\^?)|(\/$))/g;
+
+  // + remove escaped characters
+  return value?.replace(cleanerRegex, '').replace(/\\(.)/g, '$1');
 };
 
 const getQueryOperand = (item) => {
@@ -146,7 +154,6 @@ export const sourceToMongoQuery = (source) => {
   return query;
 };
 
-const cleanerRegex = /(^\^?)|([\\/]+$)|\\/g;
 const getSourceFields = (field) => ({
   $eq: (value) => ({ operator: OPERATORS.EQUAL, value }),
   $ne: (value) => ({ operator: OPERATORS.NOT_EQUAL, value }),
@@ -164,8 +171,8 @@ const getSourceFields = (field) => ({
   $empty: (value) => ({ operator: OPERATORS.EMPTY, value }),
   $regex: (value) => {
     return value?.includes('^')
-      ? { operator: OPERATORS.STARTS_WITH, value: value?.replace(cleanerRegex, '') }
-      : { operator: OPERATORS.CONTAINS, value: value?.replace(cleanerRegex, '') };
+      ? { operator: OPERATORS.STARTS_WITH, value: unescapeRegex(value) }
+      : { operator: OPERATORS.CONTAINS, value: unescapeRegex(value) };
   },
 }[field]);
 


### PR DESCRIPTION
In the current implementation which was completed in https://github.com/folio-org/ui-plugin-query-builder/pull/171, escaping occurs in several stages, which leads to an unnecessary number of backslashes. Example:

- User enters such input string: `"weird test /// ** symbols )))"`
- Inside plugin all special symbols will be escaped to have valid regex string. After modification it looks like this: `"weird test \\/\\/\\/ \\*\\* symbols \\)\\)\\)"`. This string is output of query-builder plugin.
- Inside bulk-edit, list-app this value will be strigified via `JSON.stringify()` before put to request's body, and becames `"weird test \\\\/\\\\/\\\\/ \\\\*\\\\* symbols \\\\)\\\\)\\\\)"`

In scope of this PR we are removing escaping from initial values, because we should clear it to "user input like" value.
In scope of [PR](https://github.com/folio-org/ui-lists/pull/215)  for list app, we clear all user-friendly queries from backslashes. 

![escaping](https://github.com/user-attachments/assets/216c27ac-e67d-4cda-9845-f0dd1a597705)

This PR continues https://github.com/folio-org/ui-plugin-query-builder/pull/171, update of changelog is not required.

