### PR TITLE
UIPQB-156: Nested table data display is inconsistent with regular result viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change history for ui-plugin-query-builder
 
+* [UIPQB-156](https://folio-org.atlassian.net/browse/UIPQB-156) Nested table data display is inconsistent with regular result viewer.
 * [UIPQB-157](https://folio-org.atlassian.net/browse/UIPQB-157) Add stop polling mechanism for useAsyncDataSource after 3 retries.
 
 ## [1.2.3](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.3) (2024-11-12)

--- a/src/QueryBuilder/ResultViewer/DynamicTable/DynamicTable.js
+++ b/src/QueryBuilder/ResultViewer/DynamicTable/DynamicTable.js
@@ -1,28 +1,14 @@
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
-import { FormattedDate, FormattedMessage } from 'react-intl';
-import { DATA_TYPES } from '../../../constants/dataTypes';
+import { useIntl } from 'react-intl';
 import css from './DynamicTable.css';
+import { formatValueByDataType } from '../utils';
 
 const columnStyle = { width: '180px', minWidth: '180px' };
 
-function getCellValue(row, property) {
-  // typeof check to ensure we don't try to display null/undefined as a booleans
-  if (property.dataType.dataType === DATA_TYPES.BooleanType && typeof row[property.property] === 'boolean') {
-    return row[property.property]
-      ? <FormattedMessage id="ui-plugin-query-builder.options.true" />
-      : <FormattedMessage id="ui-plugin-query-builder.options.false" />;
-  }
-
-  if (property.dataType.dataType === DATA_TYPES.DateType) {
-    return row[property.property] ? <FormattedDate value={row[property.property]} /> : '';
-  }
-
-  return row[property.property];
-}
-
 export const DynamicTable = ({ properties, values }) => {
   const tableBodyRows = useMemo(() => JSON.parse(values ?? '[]'), [values]);
+  const intl = useIntl();
 
   if (!values) return null;
 
@@ -40,11 +26,15 @@ export const DynamicTable = ({ properties, values }) => {
         </tr>
       </thead>
       <tbody>
-        {tableBodyRows.map((row, index) => (
-          <tr key={index}>
+        {tableBodyRows.map((row, rowIndex) => (
+          <tr key={rowIndex}>
             {properties?.map((cell) => (
               <td key={cell.property} style={columnStyle}>
-                {getCellValue(row, cell)}
+                {formatValueByDataType(
+                  row[cell.property],
+                  cell.dataType.dataType,
+                  intl,
+                )}
               </td>
             ))}
           </tr>

--- a/src/QueryBuilder/ResultViewer/helpers.js
+++ b/src/QueryBuilder/ResultViewer/helpers.js
@@ -1,7 +1,5 @@
-import { FormattedDate } from 'react-intl';
-import { formattedLanguageName } from '@folio/stripes/components';
-import { DATA_TYPES } from '../../constants/dataTypes';
 import { DynamicTable } from './DynamicTable/DynamicTable';
+import { formatValueByDataType } from './utils';
 
 export const getTableMetadata = (entityType, forcedVisibleValues, intl) => {
   const defaultColumns = (entityType?.columns?.map((cell) => ({
@@ -39,26 +37,14 @@ export const getTableMetadata = (entityType, forcedVisibleValues, intl) => {
 
       if (properties?.length) {
         return <DynamicTable properties={properties} values={val} />;
-      } else if (dataType === DATA_TYPES.DateType) {
-        return val ? <FormattedDate value={val} /> : '';
-      } else if (dataType === DATA_TYPES.ArrayType) {
-        // Special case for instance languages, to format them as translated strings
-        if (value === 'instance.languages') {
-          return val?.map(lang => formattedLanguageName(lang, intl)).join(' | ');
-        }
-
-        return val?.join(' | ');
-      } else if (dataType === DATA_TYPES.NumberType || dataType === DATA_TYPES.IntegerType) {
-        if (val === undefined) {
-          return '';
-        }
-
-        return val;
-      } else {
-        // If value is empty we will return empty string
-        // instead of undefined
-        return val || '';
       }
+
+      return formatValueByDataType(
+        val,
+        dataType,
+        intl,
+        { isInstanceLanguages: value === 'instance.languages' },
+      );
     };
 
     return formatted;

--- a/src/QueryBuilder/ResultViewer/utils.js
+++ b/src/QueryBuilder/ResultViewer/utils.js
@@ -1,0 +1,35 @@
+import { FormattedMessage, FormattedDate } from 'react-intl';
+
+import { formattedLanguageName } from '@folio/stripes/components';
+
+import { DATA_TYPES } from '../../constants/dataTypes';
+
+export const formatValueByDataType = (value, dataType, intl, additionalParams = {}) => {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  switch (dataType) {
+    case DATA_TYPES.BooleanType:
+      return value
+        ? <FormattedMessage id="ui-plugin-query-builder.options.true" />
+        : <FormattedMessage id="ui-plugin-query-builder.options.false" />;
+
+    case DATA_TYPES.DateType:
+      return <FormattedDate value={value} />;
+
+    case DATA_TYPES.ArrayType:
+      if (additionalParams?.isInstanceLanguages) {
+        return value.map(lang => formattedLanguageName(lang, intl)).join(' | ');
+      }
+
+      return value.join(' | ');
+
+    case DATA_TYPES.NumberType:
+    case DATA_TYPES.IntegerType:
+      return value;
+
+    default:
+      return value || '';
+  }
+};


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-156

Here we add unified formatting for `ResultViewer` and `DynamicalTable`.

Note: `formatValueByDataType` was added to a separate file to prevent the cycle dependency.