### PR TITLE
UIPQB-159: [Lists] Empty columns are displaying when the user duplicates the list and the refresh is in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change history for ui-plugin-query-builder
 
+* [UIPQB-159](https://folio-org.atlassian.net/browse/UIPQB-159) [Lists] Empty columns are displaying when the user duplicates the list and the refresh is in progress
 * [UIPQB-156](https://folio-org.atlassian.net/browse/UIPQB-156) Nested table data display is inconsistent with regular result viewer.
 * [UIPQB-157](https://folio-org.atlassian.net/browse/UIPQB-157) Add stop polling mechanism for useAsyncDataSource after 3 retries.
 

--- a/src/QueryBuilder/ResultViewer/ResultViewer.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.js
@@ -125,7 +125,10 @@ export const ResultViewer = ({
   );
 
   const renderTable = () => {
-    const showSpinner = isEmpty(lastNotEmptyContent) && (isListLoading || isContentDataLoading) && isEmpty(contentData);
+    const showSpinner =
+        refreshInProgress
+        ||
+        isEmpty(lastNotEmptyContent) && (isListLoading || isContentDataLoading ) && isEmpty(contentData);
 
     return (
       <Row center="xs">

--- a/src/QueryBuilder/ResultViewer/ResultViewer.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.js
@@ -128,7 +128,7 @@ export const ResultViewer = ({
     const showSpinner =
         refreshInProgress
         ||
-        isEmpty(lastNotEmptyContent) && (isListLoading || isContentDataLoading ) && isEmpty(contentData);
+        (isEmpty(lastNotEmptyContent) && (isListLoading || isContentDataLoading) && isEmpty(contentData));
 
     return (
       <Row center="xs">


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-159

Here we added a condition to `showspinner` if `refreshInProgress` to prevent rendering empty `MLC`.


https://github.com/user-attachments/assets/92cbe3ee-4cfb-43da-9b87-63b05fdfa92c

