### PR TITLE
UIPQB-128: Invalid fields handling > Errors when query includes a deleted custom field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [UIPQB-159](https://folio-org.atlassian.net/browse/UIPQB-159) [Lists] Empty columns are displaying when the user duplicates the list and the refresh is in progress
 * [UIPQB-160](https://folio-org.atlassian.net/browse/UIPQB-160) [QB] Update the text in the query builder after 3 attempts result in 500 errors.
+* [UIPQB-128](https://folio-org.atlassian.net/browse/UIPQB-128) Invalid fields handling > Errors when query includes a deleted custom field.
 
 ## [1.2.4](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.4) (2024-11-27)
 

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -185,6 +185,26 @@ const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOption
 
   if (operator) {
     const fieldItem = fieldOptions.find(f => f.value === field);
+    const defaultItem = fieldOptions[0]
+
+    // Exceptional case, when queried field were deleted
+    if (!fieldItem) {
+      return {
+        boolean: { options: booleanOptions, current: boolean },
+        field: { options: fieldOptions, current: field, dataType: defaultItem?.dataType },
+        operator: {
+          dataType: defaultItem?.dataType,
+          options: getOperatorOptions({
+            dataType: defaultItem?.dataType,
+            hasSourceOrValues: defaultItem?.value || defaultItem?.source,
+            intl,
+          }),
+          current: '',
+        },
+        value: { current: '', source: defaultItem?.source, options: defaultItem?.values },
+      };
+    }
+
     const { dataType, values, source } = fieldItem;
     const hasSourceOrValues = values || source;
     let formattedValue;

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -185,7 +185,7 @@ const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOption
 
   if (operator) {
     const fieldItem = fieldOptions.find(f => f.value === field);
-    const defaultItem = fieldOptions[0]
+    const defaultItem = fieldOptions[0];
 
     // Exceptional case, when queried field were deleted
     if (!fieldItem) {

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -220,6 +220,60 @@ describe('mongoQueryToSource()', () => {
 
     expect(result).toEqual(initial);
   });
+
+  it('should handle case when queried field is deleted', async () => {
+    const initialValuesUpdated = {
+      $and: [
+        { user_first_name: { $eq: 'value' } },
+        { delegate_languages: { $empty: true } },
+      ],
+    };
+
+    const defaultField = fieldOptions[0];
+
+    const result = await mongoQueryToSource({
+      initialValues: initialValuesUpdated,
+      booleanOptions,
+      fieldOptions,
+      intl: { formatMessage: jest.fn() },
+      getParamsSource: jest.fn(),
+    });
+
+    expect(result).toEqual([
+      {
+        boolean: { options: booleanOptions, current: '$and' },
+        field: {
+          options: fieldOptions,
+          current: 'user_first_name',
+          dataType: 'stringType',
+        },
+        operator: {
+          dataType: 'stringType',
+          options: expect.any(Array),
+          current: '==',
+        },
+        value: { current: 'value', source: undefined, options: undefined },
+      },
+      {
+        boolean: { options: booleanOptions, current: '$and' },
+        field: {
+          options: fieldOptions,
+          current: 'delegate_languages',
+          dataType: defaultField?.dataType,
+        },
+        operator: {
+          dataType: defaultField?.dataType,
+          options: expect.any(Array),
+          current: '',
+        },
+        value: {
+          current: '',
+          source: defaultField?.source,
+          options: defaultField?.values,
+        },
+      },
+    ]);
+  });
 });
 
 describe('isQueryValid', () => {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-128

Here, we added a case of parsing a `mongo` query with default values in dropdowns because custom fields used for the query can be deleted. By default, if the field is deleted, we will render the default unselected value inside the query builder to prevent the plugin from crashing.

https://github.com/user-attachments/assets/28c0877a-3466-45ab-a92a-471f1f39bac2

