### PR TITLE
UIPQB-175: Displays the "Smth went wrong" page, when the user clicks on "Select operator" dropdown and selects any of them, if there are deleted custom fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [UIPQB-168](https://folio-org.atlassian.net/browse/UIPQB-168) Allow editing queries containing no fields.
 * [UIPQB-141](https://folio-org.atlassian.net/browse/UIPQB-141) Modal dialog focus inconsistencies across screenreaders.
+* [UIPQB-175](https://folio-org.atlassian.net/browse/UIPQB-175) Displays the "Smth went wrong" page, when the user clicks on "Select operator" dropdown and selects any of them, if there are deleted custom fields.
 
 ## [1.2.6](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.6) (2024-12-11)
 

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -191,17 +191,11 @@ const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOption
     if (!fieldItem) {
       return {
         boolean: { options: booleanOptions, current: boolean },
-        field: { options: fieldOptions, current: field, dataType: defaultItem?.dataType },
+        field: { options: fieldOptions, dataType: defaultItem?.dataType },
         operator: {
-          dataType: defaultItem?.dataType,
-          options: getOperatorOptions({
-            dataType: defaultItem?.dataType,
-            hasSourceOrValues: defaultItem?.value || defaultItem?.source,
-            intl,
-          }),
           current: '',
         },
-        value: { current: '', source: defaultItem?.source, options: defaultItem?.values },
+        value: { current: '' },
       };
     }
 

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -258,18 +258,13 @@ describe('mongoQueryToSource()', () => {
         boolean: { options: booleanOptions, current: '$and' },
         field: {
           options: fieldOptions,
-          current: 'delegate_languages',
           dataType: defaultField?.dataType,
         },
         operator: {
-          dataType: defaultField?.dataType,
-          options: expect.any(Array),
           current: '',
         },
         value: {
           current: '',
-          source: defaultField?.source,
-          options: defaultField?.values,
         },
       },
     ]);


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-175

Here we delete the operator key for the default value, coz we don't need to render the operator select if field was deleted.


https://github.com/user-attachments/assets/9f40426b-7207-482f-87e1-83e4ca5c70e7

