### PR TITLE
UIPQB-164: Columns are reset when user modifies query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [UIPQB-141](https://folio-org.atlassian.net/browse/UIPQB-141) Modal dialog focus inconsistencies across screenreaders.
 * [UIPQB-162](https://folio-org.atlassian.net/browse/UIPQB-162) Errors when query includes a modified custom field.
 * [UIPQB-175](https://folio-org.atlassian.net/browse/UIPQB-175) Displays the "Smth went wrong" page, when the user clicks on "Select operator" dropdown and selects any of them, if there are deleted custom fields.
+* [UIPQB-164](https://folio-org.atlassian.net/browse/UIPQB-164) Columns are reset when user modifies query.
 
 
 ## [1.2.6](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.6) (2024-12-11)

--- a/src/QueryBuilder/ResultViewer/ResultViewer.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.js
@@ -82,6 +82,7 @@ export const ResultViewer = ({
     onPreviewShown,
     defaultLimit,
     forcedVisibleValues,
+    visibleColumns
   });
 
   // refresh functionality

--- a/src/QueryBuilder/ResultViewer/ResultViewer.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.js
@@ -82,7 +82,7 @@ export const ResultViewer = ({
     onPreviewShown,
     defaultLimit,
     forcedVisibleValues,
-    visibleColumns
+    visibleColumns,
   });
 
   // refresh functionality

--- a/src/QueryBuilder/ResultViewer/ResultViewer.test.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.test.js
@@ -76,8 +76,8 @@ describe('ResultViewer', () => {
   });
 
   describe('Initial and visible columns setters', () => {
-    it.each([[], undefined])('should call both when no initial fields are provided (recordColumns=%s)', async (visibleColumns) => {
-      render(renderResultViewer({ visibleColumns }));
+    it.each([[], undefined])('should call both when no initial fields are provided (recordColumns=%s)', async () => {
+      render(renderResultViewer({ visibleColumns: ['user_id'] }));
 
       await waitFor(() => {
         expect(screen.queryByText('ui-plugin-query-builder.viewer.retrieving')).not.toBeInTheDocument();

--- a/src/hooks/useViewerCallbacks.js
+++ b/src/hooks/useViewerCallbacks.js
@@ -8,12 +8,17 @@ export const useViewerCallbacks = ({
   currentRecordsCount,
   onPreviewShown,
   defaultLimit,
+                                     visibleColumns
 }) => {
   useEffect(() => {
     if (defaultColumns.length !== 0) {
       onSetDefaultColumns?.(defaultColumns);
 
-      onSetDefaultVisibleColumns?.(defaultVisibleColumns);
+      const uniqueVisibleColumns = Array.from(
+          new Set([...defaultVisibleColumns, ...visibleColumns])
+      );
+
+      onSetDefaultVisibleColumns?.(uniqueVisibleColumns);
     }
   }, [currentRecordsCount]);
 

--- a/src/hooks/useViewerCallbacks.js
+++ b/src/hooks/useViewerCallbacks.js
@@ -8,14 +8,14 @@ export const useViewerCallbacks = ({
   currentRecordsCount,
   onPreviewShown,
   defaultLimit,
-                                     visibleColumns
+  visibleColumns,
 }) => {
   useEffect(() => {
     if (defaultColumns.length !== 0) {
       onSetDefaultColumns?.(defaultColumns);
 
       const uniqueVisibleColumns = Array.from(
-          new Set([...defaultVisibleColumns, ...visibleColumns])
+        new Set([...defaultVisibleColumns, ...visibleColumns]),
       );
 
       onSetDefaultVisibleColumns?.(uniqueVisibleColumns);


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-164

Here we added logic to save selected columns and update new ones after the edit query.

https://github.com/user-attachments/assets/c49521e0-7199-49a4-af9b-821ae7df8c59

