### PR TITLE
UIPQB-185: Missing spaces and pipe delimiter for some fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * [UIPQB-164](https://folio-org.atlassian.net/browse/UIPQB-164) Columns are reset when user modifies query.
+* [UIPQB-185](https://folio-org.atlassian.net/browse/UIPQB-185) Missing spaces and pipe delimiter for some fields.
 
 ## [1.2.8](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.8) (2025-01-09)
 

--- a/src/QueryBuilder/ResultViewer/utils.js
+++ b/src/QueryBuilder/ResultViewer/utils.js
@@ -29,6 +29,7 @@ export const formatValueByDataType = (value, dataType, intl, additionalParams = 
     case DATA_TYPES.DateType:
       return <FormattedDate value={value} />;
 
+    case DATA_TYPES.JsonbArrayType:
     case DATA_TYPES.ArrayType:
       if (additionalParams?.isInstanceLanguages) {
         return value.map((lang) => formattedLanguageName(lang, intl)).join(' | ');


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-185

Here we updated formatter for `JSONb Arrays`.
<img width="1116" alt="Screenshot 2025-01-16 at 13 31 16" src="https://github.com/user-attachments/assets/83aba97a-1d89-460e-891e-a73189f55c22" />
