### PR TITLE
UIPQB-164: Columns are reset when user modifies query (follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,11 @@
 ## IN PROGRESS
 
 * [UIPQB-164](https://folio-org.atlassian.net/browse/UIPQB-164) Columns are reset when user modifies query.
-
+* [UIPQB-182](https://folio-org.atlassian.net/browse/UIPQB-182) Add ability to remove first query parameter.
 
 ## [1.2.9](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.9) (2025-01-22)
 
 * [UIPQB-185](https://folio-org.atlassian.net/browse/UIPQB-185) Missing spaces and pipe delimiter for some fields.
-* [UIPQB-182](https://folio-org.atlassian.net/browse/UIPQB-182) Add ability to remove first query parameter.
 
 ## [1.2.8](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.8) (2025-01-09)
 

--- a/src/hooks/useViewerCallbacks.js
+++ b/src/hooks/useViewerCallbacks.js
@@ -9,16 +9,15 @@ export const useViewerCallbacks = ({
   onPreviewShown,
   defaultLimit,
   visibleColumns,
+  forcedVisibleValues,
 }) => {
   useEffect(() => {
     if (defaultColumns.length > 0) {
       onSetDefaultColumns?.(defaultColumns);
 
-      if (!visibleColumns?.length) {
-        onSetDefaultVisibleColumns?.(defaultVisibleColumns);
-      }
+      onSetDefaultVisibleColumns?.(Array.from(new Set([...defaultVisibleColumns, ...visibleColumns])));
     }
-  }, [currentRecordsCount]);
+  }, [currentRecordsCount, forcedVisibleValues]);
 
   useEffect(() => {
     if (currentRecordsCount) onPreviewShown?.({ currentRecordsCount, defaultLimit });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-164

Here we fixed ithe ssue with the force visible values. It's follow-up PR.