### PR TITLE
UIPQB-183: Show custom field labels in "Query" box of query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [UIPQB-182](https://folio-org.atlassian.net/browse/UIPQB-182) Add ability to remove first query parameter.
 * [UIPQB-181](https://folio-org.atlassian.net/browse/UIPQB-181) The user-friendly query contains random dates instead of true/false values.
 * [UIPQB-180](https://folio-org.atlassian.net/browse/UIPQB-180) Don't reset 'Value' when operator is changed
+* [UIPQB-183](https://folio-org.atlassian.net/browse/UIPQB-183) Show custom field labels in "Query" box of query builder.
+* [UIPQB-184](https://folio-org.atlassian.net/browse/UIPQB-184) Show array field labels in "Query" box of query builder.
 
 ## [1.2.9](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.9) (2025-01-22)
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
@@ -110,7 +110,7 @@ export const RepeatableFields = memo(({ source, setSource, getParamsSource, colu
           [COLUMN_KEYS.VALUE]: {
             options: memorizedField.values,
             source: memorizedField.source,
-            current: retainValueOnOperatorChange(memorizedOperator, value, memorizedValue),
+            current: retainValueOnOperatorChange(memorizedOperator, value, memorizedValue, source[index].value),
           },
         };
       }

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -2,6 +2,7 @@ import { COLUMN_KEYS } from '../../../constants/columnKeys';
 import { valueBuilder } from './valueBuilder';
 import { BOOLEAN_OPERATORS, BOOLEAN_OPERATORS_MAP, OPERATORS } from '../../../constants/operators';
 import { getOperatorOptions } from './selectOptions';
+import { findLabelByValue } from '../../ResultViewer/utils';
 
 export const DEFAULT_PREVIEW_INTERVAL = 3000;
 
@@ -11,8 +12,9 @@ export const getQueryStr = (rows, fieldOptions, intl, timezone) => {
     const field = row[COLUMN_KEYS.FIELD].current;
     const operator = row[COLUMN_KEYS.OPERATOR].current;
     const value = row[COLUMN_KEYS.VALUE].current;
-    const builtValue = valueBuilder({ value, field, operator, fieldOptions, intl, timezone });
-    const baseQuery = `(${field} ${operator} ${builtValue})`;
+    const labeledValue = findLabelByValue(row[COLUMN_KEYS.VALUE], value);
+    const builtValue = valueBuilder({ value: labeledValue, field, operator, fieldOptions, intl, timezone });
+    const baseQuery = `(${findLabelByValue(row[COLUMN_KEYS.FIELD], field)} ${operator} ${builtValue})`;
 
     // if there aren't values yet - return empty string
     if (![bool, field, operator, value].some(val => Boolean(val))) {

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
@@ -2,9 +2,16 @@ import { dayjs } from '@folio/stripes/components';
 import { DATA_TYPES } from '../../../constants/dataTypes';
 import { OPERATORS, OPERATORS_GROUPS_NAME } from '../../../constants/operators';
 import { getOperatorType } from './selectOptions';
+import { findLabelByValue } from '../../ResultViewer/utils';
 
 export const getCommaSeparatedStr = (arr) => {
-  const str = arr?.map(el => `"${el?.value}"`).join(',');
+  const str = arr?.map(el => {
+    if (/^(_custom_field|opt_)/.test(el.value)) {
+      return `"${el?.label}"`;
+    }
+
+    return `"${el?.value}"`;
+  }).join(',');
 
   return `(${str})`;
 };
@@ -82,6 +89,7 @@ export const retainValueOnOperatorChange = (
   prevOperator,
   newOperator,
   prevValue,
+  options = [],
 ) => {
   const prevType = getOperatorType(prevOperator);
   const newType = getOperatorType(newOperator);
@@ -95,7 +103,7 @@ export const retainValueOnOperatorChange = (
   }
 
   if (prevType === OPERATORS_GROUPS_NAME.COMPARISON && newType === OPERATORS_GROUPS_NAME.ARRAY_COMPARISON) {
-    return [{ value: prevValue, label: prevValue }];
+    return [{ value: prevValue, label: findLabelByValue(options, prevValue) }];
   }
 
   if (prevType === OPERATORS_GROUPS_NAME.ARRAY_COMPARISON && newType === OPERATORS_GROUPS_NAME.COMPARISON) {

--- a/src/QueryBuilder/ResultViewer/utils.js
+++ b/src/QueryBuilder/ResultViewer/utils.js
@@ -45,3 +45,11 @@ export const formatValueByDataType = (value, dataType, intl, additionalParams = 
       return value || '';
   }
 };
+
+export const findLabelByValue = (options, value) => {
+  // Exceptional case for custom field, that can be identified using that pattern,
+  // that comes from JSONB
+  if (!/^(_custom_field|opt_)/.test(value) || Array.isArray(value)) return value;
+
+  return options?.options.find(option => option.value === value)?.label;
+};

--- a/src/QueryBuilder/ResultViewer/utils.test.js
+++ b/src/QueryBuilder/ResultViewer/utils.test.js
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { DATA_TYPES } from '../../constants/dataTypes';
-import { formatValueByDataType } from './utils';
+import { findLabelByValue, formatValueByDataType } from './utils';
 
 describe('formatValueByDataType returns correct value', () => {
   test.each([
@@ -35,5 +35,37 @@ describe('formatValueByDataType returns correct value', () => {
     } else {
       expect(render(<IntlProvider>{formatted}</IntlProvider>).container.innerHTML).toBe(expected);
     }
+  });
+});
+
+describe('findLabelByValue', () => {
+  const mockOptions = {
+    options: [
+      { value: 'opt_1', label: 'Option 1' },
+      { value: 'opt_2', label: 'Option 2' },
+      { value: '_custom_field_123', label: 'Custom Field 123' },
+    ],
+  };
+
+  it('should return the value if it does not start with _custom_field or opt_', () => {
+    expect(findLabelByValue(mockOptions, 'random_value')).toBe('random_value');
+  });
+
+  it('should return the value if it is an array', () => {
+    expect(findLabelByValue(mockOptions, ['opt_1', 'opt_2'])).toEqual(['opt_1', 'opt_2']);
+  });
+
+  it('should return the label if the value exists in options', () => {
+    expect(findLabelByValue(mockOptions, 'opt_1')).toBe('Option 1');
+    expect(findLabelByValue(mockOptions, '_custom_field_123')).toBe('Custom Field 123');
+  });
+
+  it('should return undefined if the value is not found in options', () => {
+    expect(findLabelByValue(mockOptions, 'opt_999')).toBeUndefined();
+  });
+
+  it('should handle null or undefined options without throwing an error', () => {
+    expect(findLabelByValue(null, 'opt_1')).toBeUndefined();
+    expect(findLabelByValue(undefined, 'opt_1')).toBeUndefined();
   });
 });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-183
https://folio-org.atlassian.net/browse/UIPQB-184

Here we added functionality to show the correct label for custom fields.


https://github.com/user-attachments/assets/2baacb30-8921-45fe-ab6f-f16849a8abcf

