### PR TITLE
UIPQB-187: Ignore/remove invalid values for dropdown fields when editing a query in the query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [UIPQB-180](https://folio-org.atlassian.net/browse/UIPQB-180) Don't reset 'Value' when operator is changed
 * [UIPQB-183](https://folio-org.atlassian.net/browse/UIPQB-183) Show custom field labels in "Query" box of query builder.
 * [UIPQB-184](https://folio-org.atlassian.net/browse/UIPQB-184) Show array field labels in "Query" box of query builder.
+* [UIPQB-187](https://folio-org.atlassian.net/browse/UIPQB-187) Ignore/remove invalid values for dropdown fields when editing a query in the query builder.
 
 ## [1.2.9](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.9) (2025-01-22)
 

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -216,6 +216,7 @@ const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOption
           current: '',
         },
         value: { current: '' },
+        deleted: true
       };
     }
 
@@ -234,7 +235,7 @@ const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOption
         }).then((data) => data?.content);
       }
 
-      formattedValue = value.map(val => params?.find(param => param.value === val));
+      formattedValue = value.map(val => params?.find(param => param.value === val)).filter(val => val !== undefined);
     }
 
     return {
@@ -279,7 +280,9 @@ export const mongoQueryToSource = async ({
         ...sharedArgs,
       });
 
-      formattedSource.push(formattedItem);
+      if (!formattedItem?.deleted) {
+        formattedSource.push(formattedItem);
+      }
     }
 
     return formattedSource;

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -216,7 +216,7 @@ const getFormattedSourceField = async ({ item, intl, booleanOptions, fieldOption
           current: '',
         },
         value: { current: '' },
-        deleted: true
+        deleted: true,
       };
     }
 

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -229,8 +229,6 @@ describe('mongoQueryToSource()', () => {
       ],
     };
 
-    const defaultField = fieldOptions[0];
-
     const result = await mongoQueryToSource({
       initialValues: initialValuesUpdated,
       booleanOptions,
@@ -253,19 +251,6 @@ describe('mongoQueryToSource()', () => {
           current: '==',
         },
         value: { current: 'value', source: undefined, options: undefined },
-      },
-      {
-        boolean: { options: booleanOptions, current: '$and' },
-        field: {
-          options: fieldOptions,
-          dataType: defaultField?.dataType,
-        },
-        operator: {
-          current: '',
-        },
-        value: {
-          current: '',
-        },
       },
     ]);
   });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-187

Here we update the logic for handling deleted custom fields and values from those fields.

https://github.com/user-attachments/assets/e690ea53-c801-488e-aa05-0ca5f6224e3b

