### PR TITLE
UIPQB-192: Query builder shouldn't show 0 results when a query fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [UIPQB-183](https://folio-org.atlassian.net/browse/UIPQB-183) Show custom field labels in "Query" box of query builder.
 * [UIPQB-184](https://folio-org.atlassian.net/browse/UIPQB-184) Show array field labels in "Query" box of query builder.
 * [UIPQB-187](https://folio-org.atlassian.net/browse/UIPQB-187) Ignore/remove invalid values for dropdown fields when editing a query in the query builder.
+* [UIPQB-192](https://folio-org.atlassian.net/browse/UIPQB-192) Query builder shouldn't show 0 results when a query fails.
 
 ## [1.2.9](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.9) (2025-01-22)
 

--- a/src/QueryBuilder/QueryBuilder/TestQuery/TestQuery.js
+++ b/src/QueryBuilder/QueryBuilder/TestQuery/TestQuery.js
@@ -129,6 +129,7 @@ export const TestQuery = ({
         total={total}
         limit={limit}
         isInProgress={isInProgress}
+        status={status}
       />
     );
   };

--- a/src/QueryBuilder/QueryBuilder/TestQuery/ViewerHeadline/ViewerHeadline.js
+++ b/src/QueryBuilder/QueryBuilder/TestQuery/ViewerHeadline/ViewerHeadline.js
@@ -1,4 +1,4 @@
-import React, { memo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Loading } from '@folio/stripes/components';
 import PropTypes from 'prop-types';
@@ -9,15 +9,20 @@ export const ViewerHeadline = memo(({ limit, total, isInProgress, status }) => {
   const hasFailed = status === QUERY_DETAILS_STATUSES.FAILED;
   const isEmpty = Number(total) === 0;
 
+  const title = useMemo(() => {
+    if (hasFailed) {
+      return <FormattedMessage id="error.occurredMessage" />;
+    }
+    if (isEmpty) {
+      return <FormattedMessage id="ui-plugin-query-builder.modal.preview.title.empty" values={{ total }} />;
+    }
+
+    return <FormattedMessage id="ui-plugin-query-builder.modal.preview.title" values={{ total, limit }} />;
+  }, [hasFailed, isEmpty, total, limit]);
+
   return (
     <>
-      {hasFailed ? (
-        <FormattedMessage id="ui-plugin-query-builder.error.occurredMessage" />
-      ) : isEmpty ? (
-        <FormattedMessage id="ui-plugin-query-builder.modal.preview.title.empty" values={{ total }} />
-      ) : (
-        <FormattedMessage id="ui-plugin-query-builder.modal.preview.title" values={{ total, limit }} />
-      )}
+      {title}
       {isInProgress && (
         <span className={css.AccordionHeaderLoading}>
           <FormattedMessage id="ui-plugin-query-builder.modal.preview.countingInProgress" />

--- a/src/QueryBuilder/QueryBuilder/TestQuery/ViewerHeadline/ViewerHeadline.js
+++ b/src/QueryBuilder/QueryBuilder/TestQuery/ViewerHeadline/ViewerHeadline.js
@@ -3,24 +3,21 @@ import { FormattedMessage } from 'react-intl';
 import { Loading } from '@folio/stripes/components';
 import PropTypes from 'prop-types';
 import css from '../../../QueryBuilder.css';
+import { QUERY_DETAILS_STATUSES } from '../../../../constants/query';
 
-export const ViewerHeadline = memo(({ limit, total, isInProgress }) => {
+export const ViewerHeadline = memo(({ limit, total, isInProgress, status }) => {
+  const hasFailed = status === QUERY_DETAILS_STATUSES.FAILED;
+  const isEmpty = Number(total) === 0;
+
   return (
     <>
-      {Number(total) === 0 ? (
-        <FormattedMessage
-          id="ui-plugin-query-builder.modal.preview.title.empty"
-          values={{ total }}
-        />
+      {hasFailed ? (
+        <FormattedMessage id="ui-plugin-query-builder.error.occurredMessage" />
+      ) : isEmpty ? (
+        <FormattedMessage id="ui-plugin-query-builder.modal.preview.title.empty" values={{ total }} />
       ) : (
-        <FormattedMessage
-          id="ui-plugin-query-builder.modal.preview.title"
-          values={{
-            total,
-            limit,
-          }}
-        />
-      )}{' '}
+        <FormattedMessage id="ui-plugin-query-builder.modal.preview.title" values={{ total, limit }} />
+      )}
       {isInProgress && (
         <span className={css.AccordionHeaderLoading}>
           <FormattedMessage id="ui-plugin-query-builder.modal.preview.countingInProgress" />
@@ -35,4 +32,5 @@ ViewerHeadline.propTypes = {
   limit: PropTypes.string,
   total: PropTypes.number,
   isInProgress: PropTypes.bool,
+  status: PropTypes.string,
 };

--- a/src/QueryBuilder/QueryBuilder/TestQuery/ViewerHeadline/ViewerHeadline.test.js
+++ b/src/QueryBuilder/QueryBuilder/TestQuery/ViewerHeadline/ViewerHeadline.test.js
@@ -1,0 +1,69 @@
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { ViewerHeadline } from './ViewerHeadline';
+import { QUERY_DETAILS_STATUSES } from '../../../../constants/query';
+
+const renderComponent = (props) => {
+  return render(
+    <IntlProvider locale="en">
+      <ViewerHeadline {...props} />
+    </IntlProvider>,
+  );
+};
+
+describe('ViewerHeadline', () => {
+  it('should render error message when status is "FAILED"', () => {
+    renderComponent({
+      limit: '10',
+      total: 5,
+      isInProgress: false,
+      status: QUERY_DETAILS_STATUSES.FAILED,
+    });
+
+    expect(screen.getByText(/error.occurredMessage/i)).toBeInTheDocument();
+  });
+
+  it('should render empty message when total is 0', () => {
+    renderComponent({
+      limit: '10',
+      total: 0,
+      isInProgress: false,
+      status: QUERY_DETAILS_STATUSES.SUCCESS,
+    });
+
+    expect(screen.getByText(/modal.preview.title.empty/i)).toBeInTheDocument();
+  });
+
+  it('should render total and limit message when total is greater than 0', () => {
+    renderComponent({
+      limit: '10',
+      total: 5,
+      isInProgress: false,
+      status: QUERY_DETAILS_STATUSES.SUCCESS,
+    });
+
+    expect(screen.getByText(/modal.preview.title/i)).toBeInTheDocument();
+  });
+
+  it('should show loading spinner when isInProgress is true', () => {
+    renderComponent({
+      limit: '10',
+      total: 5,
+      isInProgress: true,
+      status: QUERY_DETAILS_STATUSES.SUCCESS,
+    });
+
+    expect(screen.getByText(/modal.preview.countingInProgress/i)).toBeInTheDocument();
+  });
+
+  it('should not show loading spinner when isInProgress is false', () => {
+    renderComponent({
+      limit: '10',
+      total: 5,
+      isInProgress: false,
+      status: QUERY_DETAILS_STATUSES.SUCCESS,
+    });
+
+    expect(screen.getByText(/modal.preview.title/i)).toBeInTheDocument();
+  });
+});

--- a/src/hooks/useViewerCallbacks.js
+++ b/src/hooks/useViewerCallbacks.js
@@ -1,7 +1,4 @@
-import {
-  useEffect,
-  useMemo,
-} from 'react';
+import { useEffect } from 'react';
 
 export const useViewerCallbacks = ({
   onSetDefaultColumns,
@@ -14,11 +11,9 @@ export const useViewerCallbacks = ({
   forcedVisibleValues,
   visibleColumns,
 }) => {
-  const memoizedDefaultColumns = useMemo(() => defaultColumns, [JSON.stringify(defaultColumns)]);
-
   useEffect(() => {
     if (defaultColumns.length > 0) {
-      onSetDefaultColumns?.(memoizedDefaultColumns);
+      onSetDefaultColumns?.(defaultColumns);
 
       if (!visibleColumns?.length) {
         onSetDefaultVisibleColumns?.(Array.from(new Set([...defaultVisibleColumns, ...forcedVisibleValues || []])));
@@ -26,7 +21,7 @@ export const useViewerCallbacks = ({
         onSetDefaultVisibleColumns?.((prev) => Array.from(new Set([...prev, ...forcedVisibleValues || []])));
       }
     }
-  }, [currentRecordsCount, memoizedDefaultColumns]);
+  }, [currentRecordsCount]);
 
   useEffect(() => {
     if (currentRecordsCount) onPreviewShown?.({ currentRecordsCount, defaultLimit });

--- a/src/hooks/useViewerCallbacks.js
+++ b/src/hooks/useViewerCallbacks.js
@@ -1,4 +1,7 @@
-import { useEffect } from 'react';
+import {
+  useEffect,
+  useMemo,
+} from 'react';
 
 export const useViewerCallbacks = ({
   onSetDefaultColumns,
@@ -11,9 +14,11 @@ export const useViewerCallbacks = ({
   forcedVisibleValues,
   visibleColumns,
 }) => {
+  const memoizedDefaultColumns = useMemo(() => defaultColumns, [JSON.stringify(defaultColumns)]);
+
   useEffect(() => {
     if (defaultColumns.length > 0) {
-      onSetDefaultColumns?.(defaultColumns);
+      onSetDefaultColumns?.(memoizedDefaultColumns);
 
       if (!visibleColumns?.length) {
         onSetDefaultVisibleColumns?.(Array.from(new Set([...defaultVisibleColumns, ...forcedVisibleValues || []])));
@@ -21,7 +26,7 @@ export const useViewerCallbacks = ({
         onSetDefaultVisibleColumns?.((prev) => Array.from(new Set([...prev, ...forcedVisibleValues || []])));
       }
     }
-  }, [currentRecordsCount]);
+  }, [currentRecordsCount, memoizedDefaultColumns]);
 
   useEffect(() => {
     if (currentRecordsCount) onPreviewShown?.({ currentRecordsCount, defaultLimit });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-192

We updated cases for the "FAILED" status of a query with 200 status code.

<img width="1511" alt="Screenshot 2025-02-27 at 13 15 16" src="https://github.com/user-attachments/assets/4c762efa-82cc-49d4-964b-be4981cebb16" />
