### PR TITLE
UIPQB-198: The columns are missing in the "Actions" dropdown, after modifying the list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [UIPQB-183](https://folio-org.atlassian.net/browse/UIPQB-183) Show custom field labels in "Query" box of query builder.
 * [UIPQB-184](https://folio-org.atlassian.net/browse/UIPQB-184) Show array field labels in "Query" box of query builder.
 * [UIPQB-187](https://folio-org.atlassian.net/browse/UIPQB-187) Ignore/remove invalid values for dropdown fields when editing a query in the query builder.
+* [UIPQB-198](https://folio-org.atlassian.net/browse/UIPQB-198) The columns are missing in the "Actions" dropdown, after modifying the list.
 
 ## [1.2.9](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.9) (2025-01-22)
 

--- a/src/hooks/useViewerCallbacks.js
+++ b/src/hooks/useViewerCallbacks.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
 export const useViewerCallbacks = ({
   onSetDefaultColumns,
@@ -11,9 +11,11 @@ export const useViewerCallbacks = ({
   forcedVisibleValues,
   visibleColumns,
 }) => {
+  const memoizedDefaultColumns = useMemo(() => defaultColumns, [JSON.stringify(defaultColumns)]);
+
   useEffect(() => {
     if (defaultColumns.length > 0) {
-      onSetDefaultColumns?.(defaultColumns);
+      onSetDefaultColumns?.(memoizedDefaultColumns);
 
       if (!visibleColumns?.length) {
         onSetDefaultVisibleColumns?.(Array.from(new Set([...defaultVisibleColumns, ...forcedVisibleValues || []])));
@@ -21,7 +23,7 @@ export const useViewerCallbacks = ({
         onSetDefaultVisibleColumns?.((prev) => Array.from(new Set([...prev, ...forcedVisibleValues || []])));
       }
     }
-  }, [currentRecordsCount]);
+  }, [currentRecordsCount, memoizedDefaultColumns]);
 
   useEffect(() => {
     if (currentRecordsCount) onPreviewShown?.({ currentRecordsCount, defaultLimit });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-198

Updated logic for setting `defaultColumns` that used inside the `List app.`
