### PR TITLE
UIPQB-196: Make the query builder display lists of columns in the order in which they come back from mod-fqm-manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [UIPQB-198](https://folio-org.atlassian.net/browse/UIPQB-198) The columns are missing in the "Actions" dropdown, after modifying the list.
 * [UIPQB-190](https://folio-org.atlassian.net/browse/UIPQB-190) *BREAKING* migrate react-intl to v7.
 * [UIPQB-189](https://folio-org.atlassian.net/browse/UIPQB-189) *BREAKING* migrate stripes-* dependencies.
+* [UIPQB-196](https://folio-org.atlassian.net/browse/UIPQB-196) Make the query builder display lists of columns in the order in which they come back from mod-fqm-manager.
 
 ## [1.2.9](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.9) (2025-01-22)
 

--- a/src/QueryBuilder/ResultViewer/helpers.js
+++ b/src/QueryBuilder/ResultViewer/helpers.js
@@ -10,7 +10,7 @@ export const getTableMetadata = (entityType, forcedVisibleValues, intl) => {
     selected: cell.visibleByDefault,
     dataType: cell.dataType.dataType,
     properties: cell.dataType.itemDataType?.properties,
-  })) || []).sort((a, b) => a.label.localeCompare(b.label));
+  })) || []);
 
   const columnMapping = defaultColumns?.reduce((acc, { value, label }) => {
     acc[value] = label;


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-196

We removed sorting for columns in `MLC` since it dis one on the backed side.