### PR TITLE
UIPQB-194: The placeholder "Select value" appears as the selected option in the "Values" dropdown.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [UIPQB-198](https://folio-org.atlassian.net/browse/UIPQB-198) The columns are missing in the "Actions" dropdown, after modifying the list.
 * [UIPQB-190](https://folio-org.atlassian.net/browse/UIPQB-190) *BREAKING* migrate react-intl to v7.
 * [UIPQB-189](https://folio-org.atlassian.net/browse/UIPQB-189) *BREAKING* migrate stripes-* dependencies.
+* [UIPQB-194](https://folio-org.atlassian.net/browse/UIPQB-194) The placeholder "Select value" appears as the selected option in the "Values" dropdown.
 
 ## [1.2.9](https://github.com/folio-org/ui-plugin-query-builder/tree/v1.2.9) (2025-01-22)
 

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
@@ -96,6 +96,10 @@ export const retainValueOnOperatorChange = (
     return prevValue;
   }
 
+  if (prevValue === '') {
+    return '';
+  }
+
   if (prevType === OPERATORS_GROUPS_NAME.COMPARISON && newType === OPERATORS_GROUPS_NAME.ARRAY_COMPARISON) {
     if (memorizedFieldDataType === DATA_TYPES.RangedUUIDType) {
       return prevValue;

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.test.js
@@ -171,4 +171,10 @@ describe('retainValueOnOperatorChange', () => {
 
     expect(result).toBe('');
   });
+
+  test('should return an empty string when previous value is an empty string', () => {
+    const result = retainValueOnOperatorChange(OPERATORS.EQUAL, OPERATORS.IN, DATA_TYPES.StringType, '');
+
+    expect(result).toBe('');
+  });
 });


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-194

Fix the problem with the placeholder value when changing the unselected value from `COMPARISON` to `ARRAY_COMPARISON` values.