### PR TITLE
UIPQB-202: Columns reset after editing and saving a query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## IN PROGRESS
 
+* [UIPQB-202](https://folio-org.atlassian.net/browse/UIPQB-202) Columns reset after editing and saving a query.
+
 ## [2.0.0](https://github.com/folio-org/ui-plugin-query-builder/tree/v2.0.0) (2025-03-12)
 
 * [UIPQB-164](https://folio-org.atlassian.net/browse/UIPQB-164) Columns are reset when user modifies query.

--- a/src/hooks/useViewerCallbacks.js
+++ b/src/hooks/useViewerCallbacks.js
@@ -20,7 +20,7 @@ export const useViewerCallbacks = ({
       if (!visibleColumns?.length) {
         onSetDefaultVisibleColumns?.(Array.from(new Set([...defaultVisibleColumns, ...forcedVisibleValues || []])));
       } else {
-        onSetDefaultVisibleColumns?.((prev) => Array.from(new Set([...prev, ...forcedVisibleValues || []])));
+        onSetDefaultVisibleColumns?.(Array.from(new Set([...visibleColumns, ...forcedVisibleValues || []])));
       }
     }
   }, [currentRecordsCount, memoizedDefaultColumns]);


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/UIPQB-202

Fixed the column reset after editing the query. (The problem comes from `prev` state since after refreshing the list calling the rerender).


https://github.com/user-attachments/assets/4d59fecb-e346-4788-a13d-cbed74aa1b68

