### PR TITLE
[UIPQB-206] Expose new setIsModalShown prop for consumers to determine if the modal is opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## IN PROGRESS
 
 * [UIPQB-204](https://folio-org.atlassian.net/browse/UIPQB-204) Add plugin-find-organization for "Organization — Name" and "Organization — Code"
+* [UIPQB-206](https://folio-org.atlassian.net/browse/UIPQB-206) Expose `setIsModalShown` prop for consumers to know when the modal is open
 
 ## [2.0.1](https://github.com/folio-org/ui-plugin-query-builder/tree/v2.0.0) (2025-03-26)
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilder.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilder.js
@@ -1,4 +1,5 @@
 import React, {
+  useCallback,
   useState,
 } from 'react';
 import { FormattedMessage } from 'react-intl';
@@ -10,13 +11,19 @@ import { queryBuilderModalPropTypes } from '../propTypes';
 export const QueryBuilder = ({
   disabled,
   triggerButtonLabel,
+  setIsModalShown: externalSetIsModalShown,
   ...modalProps
 }) => {
-  const [isModalShown, setIsModalShown] = useState(false);
+  const [isModalShown, internalSetIsModalShown] = useState(false);
 
-  const openModal = () => {
+  const setIsModalShown = useCallback((isShown) => {
+    externalSetIsModalShown?.(isShown);
+    internalSetIsModalShown(isShown);
+  }, [externalSetIsModalShown]);
+
+  const openModal = useCallback(() => {
     setIsModalShown(true);
-  };
+  }, [setIsModalShown]);
 
   return (
     <>
@@ -40,5 +47,6 @@ export const QueryBuilder = ({
 QueryBuilder.propTypes = {
   disabled: PropTypes.bool,
   triggerButtonLabel: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  setIsModalShown: PropTypes.func,
   ...queryBuilderModalPropTypes,
 };


### PR DESCRIPTION
# [Jira UIPQB-206](https://folio-org.atlassian.net/browse/UIPQB-206)

## Purpose
Consumers need to know if the query builder is opened or not in some use cases, such as controlling form state and page navigation. Without this prop, consuming modules can only know that the QB is open by observing calls to test queries, etc, however, this does not exactly correlate to if the dialog is open, nor does it allow detection of the modal being closed.

`ui-lists` specifically needed this for https://folio-org.atlassian.net/browse/UILISTS-222; before this, Lists had no way of knowing if the QB was open, which was causing erroneous triggers of the "unsaved changes" prompt. Additionally, spying on the existing methods for running queries to change this behavior did not work as navigation happens directly upon the user clicking "Run query & save", disallowing any time for re-renders to allow propagating new states.