### PR TITLE
Fix initial value for boolean dropdowns

### DIFF
--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.js
@@ -28,7 +28,11 @@ export const SelectionContainer = ({
   let normalizedValue = value;
 
   if (isBooleanField && typeof value === 'string') {
-    normalizedValue = value.toLowerCase() === 'true';
+    if (value.toLowerCase() === 'true') {
+      normalizedValue = true;
+    } else if (value.toLowerCase() === 'false') {
+      normalizedValue = false;
+    }
   }
 
   const getSelectOptionsWithPlaceholder = (options) => {


### PR DESCRIPTION
## Purpose
Fix a a small bug introduced in https://github.com/folio-org/ui-plugin-query-builder/pull/243 to allow boolean dropdown menus to start with an initial value of 'Select value'