### PR TITLE
[UIPQB-231] Preserve query values when determining initial QB state

### DIFF
--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -215,6 +215,7 @@ const getFormattedSourceField = async ({
   getParamsSource,
   boolean,
   getDataOptions,
+  preserveQueryValue, // for enum values, preserves the value (used for initial value handling in QB)
 }) => {
   const [field, query] = Object.entries(item)[0];
   const fqlOperator = Object.keys(query)[0];
@@ -253,11 +254,19 @@ const getFormattedSourceField = async ({
       }).then((data) => data?.content));
     }
 
+    let key;
+
+    if (preserveQueryValue) {
+      key = 'value';
+    } else {
+      key = 'label';
+    }
+
     if (Array.isArray(value)) {
       formattedValue = value
-        .map(val => possibleValues?.find(param => param.value === val) || val);
+        .map(val => possibleValues?.find(param => param.value === val)?.[key] || val);
     } else {
-      formattedValue = possibleValues?.find(param => param.value === value)?.label;
+      formattedValue = possibleValues?.find(param => param.value === value)?.[key];
     }
 
     return {
@@ -285,11 +294,12 @@ export const fqlQueryToSource = async ({
   intl,
   getParamsSource,
   getDataOptions,
+  preserveQueryValue,
 }) => {
   if (!fieldOptions?.length || !Object.keys(initialValues).length) return [];
 
   const key = Object.keys(initialValues)[0];
-  const sharedArgs = { intl, getParamsSource, fieldOptions, getDataOptions };
+  const sharedArgs = { intl, getParamsSource, fieldOptions, getDataOptions, preserveQueryValue };
 
   // handle case when query contains boolean operators (AND, OR, etc.)
   if (Object.values(BOOLEAN_OPERATORS).includes(key)) {
@@ -325,6 +335,7 @@ export const getSourceValue = ({
   intl,
   getParamsSource,
   getDataOptions,
+  preserveQueryValue = true,
 }) => {
   // if initial value provided, and it has some items, fill the source with it
   const hasInitialValues = Object
@@ -338,6 +349,7 @@ export const getSourceValue = ({
       intl,
       getParamsSource,
       getDataOptions,
+      preserveQueryValue,
     });
   }
 
@@ -388,6 +400,7 @@ export const useQueryStr = (entityType, { source, fqlQuery }, getParamsSource) =
             intl,
             getParamsSource,
             getDataOptions,
+            preserveQueryValue: false, // pretty print
           }),
         );
       } else {


### PR DESCRIPTION
# [Jira UIPQB-231](https://folio-org.atlassian.net/browse/UIPQB-231)

## Purpose
There are two main handling types used when displaying queries in the QB: a "pretty" query for the user, and a more FQL-adjacent view with the internal field names and values. Typically, the values shown in each are the same, however, this is not the case for fields with defined `values` lists.

For these fields, we apply transformations from internal values (used in queries and returned in results) and the user-visible results. For example:

```json5
{ values: [
  { value: 'true', label: 'True' },
  { value: 'false', label: 'False' },
] }
```

This allows the lowercase `true`/`false` for queries/results, however, the actual dropdown in the QB (and the user-friendly query in the results viewer) show the proper capitalized versions.

## Approach
Adds a flag throughout several of the query handling methods to allow the caller to choose if `label`s or `value`s of these enums should be returned.