### PR TITLE
[UIPQB-220] Utilize optimized $contains and $regex operators

### DIFF
--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -140,10 +140,10 @@ const getQueryOperand = (item) => {
       queryOperand = { [field]: { $nin: getTransformedValue(value) } };
       break;
     case OPERATORS.STARTS_WITH:
-      queryOperand = { [field]: { $regex: new RegExp(`^${escapeRegex(value)}`).source } };
+      queryOperand = { [field]: { $starts_with: value } };
       break;
     case OPERATORS.CONTAINS:
-      queryOperand = { [field]: { $regex: new RegExp(escapeRegex(value)).source } };
+      queryOperand = { [field]: { $contains: value } };
       break;
     case OPERATORS.NOT_CONTAINS:
       queryOperand = { [field]: { $not_contains: value } };
@@ -195,12 +195,14 @@ const getSourceFields = (field) => ({
   $lte: (value) => ({ operator: OPERATORS.LESS_THAN_OR_EQUAL, value }),
   $in: (value) => ({ operator: OPERATORS.IN, value }),
   $nin: (value) => ({ operator: OPERATORS.NOT_IN, value }),
+  $starts_with: (value) => ({ operator: OPERATORS.STARTS_WITH, value }),
   $contains: (value) => ({ operator: OPERATORS.CONTAINS, value }),
   $contains_all: (value) => ({ operator: OPERATORS.CONTAINS_ALL, value }),
   $not_contains_all: (value) => ({ operator: OPERATORS.NOT_CONTAINS_ALL, value }),
   $contains_any: (value) => ({ operator: OPERATORS.CONTAINS_ANY, value }),
   $not_contains_any: (value) => ({ operator: OPERATORS.NOT_CONTAINS_ANY, value }),
   $empty: (value) => ({ operator: OPERATORS.EMPTY, value }),
+  // should be removed after implementation of https://folio-org.atlassian.net/browse/MODFQMMGR-614
   $regex: (value) => {
     return value?.includes('^')
       ? { operator: OPERATORS.STARTS_WITH, value: unescapeRegex(value) }

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -64,6 +64,12 @@ describe('fqlQueryToSource()', () => {
     },
     {
       boolean: { options: booleanOptions, current: '$and' },
+      field: { options: fieldOptions, current: 'user_full_name' },
+      operator: { options: expect.any(Array), current: OPERATORS.STARTS_WITH },
+      value: { current: 'Jeff' },
+    },
+    {
+      boolean: { options: booleanOptions, current: '$and' },
       field: { options: fieldOptions, current: 'user_id' },
       operator: { options: expect.any(Array), current: OPERATORS.NOT_IN },
       value: { current: 'value, value2' },
@@ -139,7 +145,8 @@ describe('fqlQueryToSource()', () => {
       { user_last_name: { $gt: 'value' } },
       { user_last_name: { $lt: 10 } },
       { user_last_name: { $gte: 'value' } },
-      { user_full_name: { $regex: 'abc' } },
+      { user_full_name: { $contains: 'abc' } },
+      { user_full_name: { $starts_with: 'Jeff' } },
       { user_id: { $nin: ['value', 'value2'] } },
       { user_id: { $in: ['value', 'value2'] } },
       { department_names: { $contains_all: ['value'] } },


### PR DESCRIPTION
# [Jira UIPQB-220](https://folio-org.atlassian.net/browse/UIPQB-220)

## Purpose
Use the ✨new✨ (ish) `$contains` and `$starts_with` operators.

This does support parsing queries with `$regex` still; this can be safely removed once [MODFQMMGR-614](https://folio-org.atlassian.net/browse/MODFQMMGR-614) is completed.