### PR TITLE
[UIPQB-243] Provide UI error when custom ET changes break a list

### DIFF
--- a/src/QueryBuilder/ResultViewer/ResultViewer.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Col, Row, Accordion, MultiColumnList, Headline, Layout, Icon } from '@folio/stripes/components';
 import { PrevNextPagination } from '@folio/stripes-acq-components';
@@ -149,9 +149,13 @@ export const ResultViewer = ({
     return isErrorOccurred ? renderErrorMessage() : renderSuccessMessage();
   };
 
-  const emptyResultMessage = intl.formatMessage(
-    { id: 'ui-plugin-query-builder.result.emptyMessage' },
-  );
+  const emptyResultMessage = useMemo(() => {
+    if (isErrorOccurred) {
+      return intl.formatMessage({ id: 'ui-plugin-query-builder.error.occurredMessage' });
+    } else {
+      return intl.formatMessage({ id: 'ui-plugin-query-builder.result.emptyMessage' });
+    }
+  }, [isErrorOccurred, intl]);
 
   const renderTable = () => {
     const showSpinner =

--- a/src/hooks/useAsyncDataSource.js
+++ b/src/hooks/useAsyncDataSource.js
@@ -12,6 +12,7 @@ import { useEntityType } from './useEntityType';
 import { QUERY_KEYS } from '../constants/query';
 
 const DEFAULT_TIMEOUT = 6000;
+const DEFAULT_MAX_RETRIES = 3;
 
 // temporary solution to emulate structuralSharing before migrating to react-query v4+
 const structuralSharing = (queryClient, key, newData) => {
@@ -47,43 +48,56 @@ export const useAsyncDataSource = ({
   const [contentDataKey] = useNamespace({ key: QUERY_KEYS.QUERY_PLUGIN_CONTENT_DATA });
   const [debouncedOffset, debouncedLimit] = useDebounce([offset, limit], 200);
   const debouncedContentQueryKeys = useDebounce(contentQueryKeys, 500);
-  const [retryCount, setRetryCount] = useState(0);
+  const [retry, setRetry] = useState(DEFAULT_MAX_RETRIES);
   const [hasShownError, setHasShownError] = useState(false);
   const [isErrorOccurred, setIsErrorOccurred] = useState(false);
-  const [needsRefresh, setNeedsRefresh] = useState(false);
-  const maxRetries = 3;
-  const { refetchInterval = noop, completeExecution = noop, keepPreviousData = false } = contentQueryOptions;
+  const {
+    refetchInterval = noop,
+    completeExecution = noop,
+    keepPreviousData = false,
+  } = contentQueryOptions;
 
   const { entityType, isContentTypeFetchedAfterMount, isEntityTypeLoading } = useEntityType({
     entityTypeDataSource,
     queryKey: entityKey,
   });
 
-  const sharedOptions = { refetchOnWindowFocus: false, keepPreviousData: true };
-  const queryKey = [namespaceKey, contentDataKey, debouncedOffset, debouncedLimit, ...debouncedContentQueryKeys];
+  const queryKey = [
+    namespaceKey,
+    contentDataKey,
+    debouncedOffset,
+    debouncedLimit,
+    ...debouncedContentQueryKeys,
+  ];
 
-  const showError = useCallback((translation) => {
-    if (!hasShownError) {
-      completeExecution();
-      showCallout({
-        type: 'error',
-        message: intl.formatMessage({ id: translation }),
-        timeout: DEFAULT_TIMEOUT,
+  const showError = useCallback(
+    (translation) => {
+      setHasShownError((h) => {
+        if (!h) {
+          completeExecution();
+          showCallout({
+            type: 'error',
+            message: intl.formatMessage({ id: translation }),
+            timeout: DEFAULT_TIMEOUT,
+          });
+          setIsErrorOccurred(true);
+        }
+
+        return true;
       });
-      setHasShownError(true);
-      setIsErrorOccurred(true);
-    }
-  }, [completeExecution, showCallout, hasShownError]);
+    },
+    [completeExecution, showCallout, hasShownError],
+  );
 
   const {
     data: recordsData,
     isLoading: isContentDataLoading,
     isFetching: isContentDataFetching,
     refetch,
-  } = useQuery(
-    {
-      queryKey,
-      queryFn: async () => {
+  } = useQuery({
+    queryKey,
+    queryFn: async () => {
+      try {
         const data = await contentDataSource({
           offset: debouncedOffset,
           limit: debouncedLimit,
@@ -91,48 +105,34 @@ export const useAsyncDataSource = ({
         });
 
         return structuralSharing(queryClient, queryKey, data);
-      },
-      refetchInterval: (query) => {
-        if (needsRefresh) {
-          showError('ui-plugin-query-builder.error.needsRefresh');
-
-          return 0;
-        } else if (retryCount === maxRetries) {
-          showError('ui-plugin-query-builder.error.sww');
-
-          return 0;
-        }
-
-        return refetchInterval(query);
-      },
-      onSuccess: (data) => {
-        setRetryCount(0);
-        setHasShownError(false);
-        setIsErrorOccurred(false);
-        setNeedsRefresh(false);
-        onSuccess(data);
-      },
-      onError: async (e) => {
+      } catch (e) {
         if ((await e.response.json()).code === 'read-list.contents.request.failed') {
-          setNeedsRefresh(true);
-        } else {
-          setRetryCount((prev) => prev + 1);
+          showError('ui-plugin-query-builder.error.needsRefresh');
+          setRetry(false);
         }
-      },
-      keepPreviousData,
-      ...sharedOptions,
+        throw e;
+      }
     },
-  );
+    refetchInterval,
+    onSuccess: (data) => {
+      setRetry(DEFAULT_MAX_RETRIES);
+      setHasShownError(false);
+      setIsErrorOccurred(false);
+      onSuccess(data);
+    },
+    onError: () => {
+      showError('ui-plugin-query-builder.error.sww');
+    },
+    refetchOnWindowFocus: false,
+    keepPreviousData,
+    retry,
+    retryDelay: 100,
+  });
 
   const { content: contentData, totalRecords, status } = recordsData || {};
 
-  const {
-    columnMapping,
-    defaultColumns,
-    defaultVisibleColumns,
-    formatter,
-    columnWidths,
-  } = getTableMetadata(entityType, forcedVisibleValues, intl);
+  const { columnMapping, defaultColumns, defaultVisibleColumns, formatter, columnWidths } =
+    getTableMetadata(entityType, forcedVisibleValues, intl);
 
   return {
     contentData,

--- a/src/hooks/useAsyncDataSource.test.js
+++ b/src/hooks/useAsyncDataSource.test.js
@@ -66,18 +66,17 @@ describe('useAsyncDataSource', () => {
     };
 
     const { result } = renderHook(
-      () =>
-        useAsyncDataSource({
-          contentDataSource,
-          entityTypeDataSource: jest.fn(),
-          offset: 0,
-          limit: 10,
-          queryParams: {},
-          onSuccess,
-          contentQueryOptions,
-          contentQueryKeys: [],
-          forcedVisibleValues: [],
-        }),
+      () => useAsyncDataSource({
+        contentDataSource,
+        entityTypeDataSource: jest.fn(),
+        offset: 0,
+        limit: 10,
+        queryParams: {},
+        onSuccess,
+        contentQueryOptions,
+        contentQueryKeys: [],
+        forcedVisibleValues: [],
+      }),
       { wrapper },
     );
 
@@ -95,10 +94,9 @@ describe('useAsyncDataSource', () => {
     const contentDataSource = () => {
       throw Object.assign(new Error(), {
         response: {
-          json: () =>
-            Promise.resolve({
-              code: 'read-list.contents.request.failed',
-            }),
+          json: () => Promise.resolve({
+            code: 'read-list.contents.request.failed',
+          }),
         },
       });
     };
@@ -106,22 +104,21 @@ describe('useAsyncDataSource', () => {
     const completeExecution = jest.fn();
 
     const { result } = renderHook(
-      () =>
-        useAsyncDataSource({
-          contentDataSource,
-          entityTypeDataSource: jest.fn(),
-          offset: 0,
-          limit: 10,
-          queryParams: {},
-          onSuccess: jest.fn(),
-          contentQueryOptions: {
-            refetchInterval: jest.fn(() => 1000),
-            completeExecution,
-            keepPreviousData: true,
-          },
-          contentQueryKeys: [],
-          forcedVisibleValues: [],
-        }),
+      () => useAsyncDataSource({
+        contentDataSource,
+        entityTypeDataSource: jest.fn(),
+        offset: 0,
+        limit: 10,
+        queryParams: {},
+        onSuccess: jest.fn(),
+        contentQueryOptions: {
+          refetchInterval: jest.fn(() => 1000),
+          completeExecution,
+          keepPreviousData: true,
+        },
+        contentQueryKeys: [],
+        forcedVisibleValues: [],
+      }),
       { wrapper },
     );
 
@@ -147,22 +144,21 @@ describe('useAsyncDataSource', () => {
     const completeExecution = jest.fn();
 
     const { result } = renderHook(
-      () =>
-        useAsyncDataSource({
-          contentDataSource,
-          entityTypeDataSource: jest.fn(),
-          offset: 0,
-          limit: 10,
-          queryParams: {},
-          onSuccess: jest.fn(),
-          contentQueryOptions: {
-            refetchInterval: jest.fn(() => 1),
-            completeExecution,
-            keepPreviousData: true,
-          },
-          contentQueryKeys: [],
-          forcedVisibleValues: [],
-        }),
+      () => useAsyncDataSource({
+        contentDataSource,
+        entityTypeDataSource: jest.fn(),
+        offset: 0,
+        limit: 10,
+        queryParams: {},
+        onSuccess: jest.fn(),
+        contentQueryOptions: {
+          refetchInterval: jest.fn(() => 1),
+          completeExecution,
+          keepPreviousData: true,
+        },
+        contentQueryKeys: [],
+        forcedVisibleValues: [],
+      }),
       { wrapper },
     );
 

--- a/src/hooks/useAsyncDataSource.test.js
+++ b/src/hooks/useAsyncDataSource.test.js
@@ -1,8 +1,9 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { act } from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { act, renderHook, waitFor } from '@testing-library/react';
 
-import { useNamespace } from '@folio/stripes/core';
 import { useShowCallout } from '@folio/stripes-acq-components';
+import { useNamespace } from '@folio/stripes/core';
 
 import { useAsyncDataSource } from './useAsyncDataSource';
 import { useDebounce } from './useDebounce';
@@ -32,9 +33,7 @@ const queryClient = new QueryClient();
 
 // eslint-disable-next-line react/prop-types
 const wrapper = ({ children }) => (
-  <QueryClientProvider client={queryClient}>
-    {children}
-  </QueryClientProvider>
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
 );
 
 const mockShowCallout = jest.fn();
@@ -66,26 +65,115 @@ describe('useAsyncDataSource', () => {
       keepPreviousData: true,
     };
 
-    const { result } = renderHook(() => useAsyncDataSource({
-      contentDataSource,
-      entityTypeDataSource: jest.fn(),
-      offset: 0,
-      limit: 10,
-      queryParams: {},
-      onSuccess,
-      contentQueryOptions,
-      contentQueryKeys: [],
-      forcedVisibleValues: [],
-    }), { wrapper });
+    const { result } = renderHook(
+      () =>
+        useAsyncDataSource({
+          contentDataSource,
+          entityTypeDataSource: jest.fn(),
+          offset: 0,
+          limit: 10,
+          queryParams: {},
+          onSuccess,
+          contentQueryOptions,
+          contentQueryKeys: [],
+          forcedVisibleValues: [],
+        }),
+      { wrapper },
+    );
 
     expect(result.current.isContentDataLoading).toBe(true);
 
-    await act(async () => {
-      await waitFor(() => expect(contentDataSource).toHaveBeenCalled());
-    });
+    await act(() => waitFor(() => expect(contentDataSource).toHaveBeenCalled()));
 
     expect(onSuccess).toHaveBeenCalled();
+    expect(result.current.isErrorOccurred).toBe(false);
     expect(result.current.contentData).toEqual([{ id: 1, name: 'Test Record' }]);
     expect(result.current.totalRecords).toBe(1);
+  });
+
+  it('should handle needs refresh case (error === read-list.contents.request.failed)', async () => {
+    const contentDataSource = () => {
+      throw Object.assign(new Error(), {
+        response: {
+          json: () =>
+            Promise.resolve({
+              code: 'read-list.contents.request.failed',
+            }),
+        },
+      });
+    };
+
+    const completeExecution = jest.fn();
+
+    const { result } = renderHook(
+      () =>
+        useAsyncDataSource({
+          contentDataSource,
+          entityTypeDataSource: jest.fn(),
+          offset: 0,
+          limit: 10,
+          queryParams: {},
+          onSuccess: jest.fn(),
+          contentQueryOptions: {
+            refetchInterval: jest.fn(() => 1000),
+            completeExecution,
+            keepPreviousData: true,
+          },
+          contentQueryKeys: [],
+          forcedVisibleValues: [],
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(completeExecution).toHaveBeenCalled());
+
+    expect(result.current.isErrorOccurred).toBe(true);
+    expect(mockShowCallout).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'ui-plugin-query-builder.error.needsRefresh',
+      timeout: 6000,
+    });
+  });
+
+  it('should handle generic error case with retries', async () => {
+    const contentDataSource = jest.fn(() => {
+      throw Object.assign(new Error(), {
+        response: {
+          json: () => Promise.resolve({}),
+        },
+      });
+    });
+
+    const completeExecution = jest.fn();
+
+    const { result } = renderHook(
+      () =>
+        useAsyncDataSource({
+          contentDataSource,
+          entityTypeDataSource: jest.fn(),
+          offset: 0,
+          limit: 10,
+          queryParams: {},
+          onSuccess: jest.fn(),
+          contentQueryOptions: {
+            refetchInterval: jest.fn(() => 1),
+            completeExecution,
+            keepPreviousData: true,
+          },
+          contentQueryKeys: [],
+          forcedVisibleValues: [],
+        }),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(contentDataSource.mock.calls.length).toBeGreaterThanOrEqual(3));
+
+    expect(completeExecution).toHaveBeenCalled();
+    expect(result.current.isErrorOccurred).toBe(true);
+    expect(mockShowCallout).toHaveBeenCalledWith({
+      type: 'error',
+      message: 'ui-plugin-query-builder.error.sww',
+      timeout: 6000,
+    });
   });
 });

--- a/translations/ui-plugin-query-builder/en.json
+++ b/translations/ui-plugin-query-builder/en.json
@@ -35,6 +35,7 @@
   "result.emptyMessage": "The list contains no items",
 
   "error.sww": "Something went wrong",
+  "error.needsRefresh": "The record type used by this list has changed; please refresh the list.",
   "error.occurredMessage": "An error occurred.",
 
   "warning.deletedField": "{value} in your query is no longer available. Please revise your query.",

--- a/translations/ui-plugin-query-builder/en_US.json
+++ b/translations/ui-plugin-query-builder/en_US.json
@@ -33,5 +33,6 @@
     "noOptionsAvailable": "No matches! Use the “Organization look-up” below to add organizations",
     "viewer.accordion.title.query": "Query: {query}",
     "userFriendlyQuery.boolean.$and": "{query1} and {query2}",
-    "control.value.placeholder.organizations": "Use the “Organization look-up” below to add values"
+    "control.value.placeholder.organizations": "Use the “Organization look-up” below to add values",
+    "error.needsRefresh": "The record type used by this list has changed; please refresh the list."
 }


### PR DESCRIPTION
Custom ET changes can break attempts to get a list's `/contents`, resulting in a special error code `read-list.contents.request.failed`. When we encounter this error, we want to show a special error message instructing the user to refresh the list.

This is straightforward enough, however, the existing error-handling was a bit awkward and used some anti-patterns in `react-query`. This is now updated to use the builtin retry functionality of `react-query` (unfortunately though, at least in the current obsolete `v3`, there is no way to catch errors before all retries fail, so we do have some extra logic in the `queryFn`). We also added some tests for the negative cases when fetching contents, as all that was previously uncovered.