### PR TITLE
UIPQB-239 Add support for DateTimeType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [UIPQB-232](https://folio-org.atlassian.net/browse/UIPQB-232) Show label aliases for inherited custom fields
 * [UIPQB-236](https://folio-org.atlassian.net/browse/UIPQB-236) Remove unsupported operators for predefined repeatable fields
 * [UIPQB-241](https://folio-org.atlassian.net/browse/UIPQB-241) Make UI behavior on search by repeatable fields consistent with search by other fields in “Build query” form, “Lists“ app
+* [UIPQB-239](https://folio-org.atlassian.net/browse/UIPQB-239) Add support for the new DateTimeType data type and update the behavior of the older DateType.
 
 ## [2.0.3](https://github.com/folio-org/ui-plugin-query-builder/tree/v2.0.3) (2025-04-18)
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
@@ -97,14 +97,27 @@ export const DataTypeInput = ({
     />
   );
 
-  const datePickerControl = () => {
+  // DateType: treat value as plain YYYY-MM-DD (timezone agnostic) by setting the timezone to UTC and setting the backendDateStandard to YYYY-MM-DD
+  const datePickerControl = () => (
+    <Datepicker
+      timeZone="UTC"
+      backendDateStandard="YYYY-MM-DD"
+      data-testid="data-input-dateType"
+      onChange={(e, _unusedValue, formattedValue) => onChange(formattedValue, index, COLUMN_KEYS.VALUE)}
+      {...rest}
+      value={value || ''}
+    />
+  );
+
+  // DateTimeType: timezone logic (store value without trailing Z after user selection)
+  const dateTimePickerControl = () => {
     const selectedValue = value;
     const formattedSelectedDate = selectedValue ? `${selectedValue}Z` : selectedValue;
 
     return (
       <Datepicker
         timeZone={timezone}
-        data-testid="data-input-dateType"
+        data-testid="data-input-dateTimeType"
         onChange={(e, _unusedValue, formattedValue) => {
           onChange(formattedValue.replace('Z', ''), index, COLUMN_KEYS.VALUE);
         }}
@@ -276,6 +289,9 @@ export const DataTypeInput = ({
 
     case DATA_TYPES.DateType:
       return datePickerControl();
+
+    case DATA_TYPES.DateTimeType:
+      return dateTimePickerControl();
 
     case DATA_TYPES.OpenUUIDType:
       return openUUIDTypeControls();

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.test.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.test.js
@@ -149,6 +149,12 @@ const arr = [
     onChange: jest.fn(),
   },
   {
+    dataType: DATA_TYPES.DateTimeType,
+    operator: OPERATORS.GREATER_THAN,
+    componentTestId: 'data-input-dateTimeType',
+    onChange: jest.fn(),
+  },
+  {
     dataType: DATA_TYPES.BooleanType,
     operator: OPERATORS.EMPTY,
     componentTestId: 'data-input-select-booleanType',

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -98,6 +98,7 @@ export const getOperatorOptions = ({
       return getOperatorsWithPlaceholder(ArrayOperators(hasSourceOrValues), intl);
 
     case DATA_TYPES.DateType:
+    case DATA_TYPES.DateTimeType:
       return getOperatorsWithPlaceholder(extendedLogicalOperators(), intl);
 
     case DATA_TYPES.ObjectType:

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -314,6 +314,27 @@ describe('select options', () => {
       });
     });
 
+    it('should return extended logical operators with placeholder for datetime type', () => {
+      const options = getOperatorOptions({
+        dataType: DATA_TYPES.DateTimeType,
+        hasSourceOrValues: false,
+        intl: intlMock,
+      });
+
+      expectFn({
+        options,
+        operators: [
+          { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
+          { label: OPERATORS_LABELS.NOT_EQUAL, value: OPERATORS.NOT_EQUAL },
+          { label: OPERATORS_LABELS.GREATER_THAN, value: OPERATORS.GREATER_THAN },
+          { label: OPERATORS_LABELS.LESS_THAN, value: OPERATORS.LESS_THAN },
+          { label: OPERATORS_LABELS.GREATER_THAN_OR_EQUAL, value: OPERATORS.GREATER_THAN_OR_EQUAL },
+          { label: OPERATORS_LABELS.LESS_THAN_OR_EQUAL, value: OPERATORS.LESS_THAN_OR_EQUAL },
+          { label: OPERATORS_LABELS.EMPTY, value: OPERATORS.EMPTY },
+        ],
+      });
+    });
+
     it('should return an empty array for unknown data type', () => {
       const options = getOperatorOptions({
         dataType: 'UnknownType',

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
@@ -68,7 +68,9 @@ export const valueBuilder = ({ value, field, operator, fieldOptions, intl, timez
 
     [DATA_TYPES.ObjectType]: () => getQuotedStr(value, isInRelatedOperator),
 
-    [DATA_TYPES.DateType]: () => getQuotedStr(formatDateToPreview(value, intl, timezone), isInRelatedOperator),
+    [DATA_TYPES.DateType]: () => getQuotedStr(value, isInRelatedOperator),
+
+    [DATA_TYPES.DateTimeType]: () => getQuotedStr(formatDateToPreview(value, intl, timezone), isInRelatedOperator),
 
     [DATA_TYPES.OpenUUIDType]: () => getFormattedUUID(value, isInRelatedOperator),
 

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.test.js
@@ -62,13 +62,35 @@ describe('valueBuilder', () => {
 
   test('should return an empty string if value is falsy for DateType', () => {
     const value = null;
+    const field = 'loan_checkout_date';
+    const operator = OPERATORS.EQUAL;
+
+    expect(valueBuilder({ value, field, operator, fieldOptions })).toBe('');
+  });
+
+  test('should return raw YYYY-MM-DD string for DateType if value is truthy', () => {
+    const value = '2024-11-06';
+    const field = 'loan_checkout_date';
+    const operator = OPERATORS.EQUAL;
+
+    // intl/timezone should have no effect on DateType
+    const intl = {
+      formatDate: () => jest.fn(() => fail('should not be used')),
+    };
+
+    expect(valueBuilder({ value, field, operator, fieldOptions, intl, timezone: 'Narnia' }))
+      .toBe('2024-11-06');
+  });
+
+  test('should return an empty string if value is falsy for DateTimeType', () => {
+    const value = null;
     const field = 'user_expiration_date';
     const operator = OPERATORS.EQUAL;
 
     expect(valueBuilder({ value, field, operator, fieldOptions })).toBe('');
   });
 
-  test('should return a string for DateType if value is truthy', () => {
+  test('should return formatted string for DateTimeType if value is truthy (timezone aware)', () => {
     const value = '2024-11-06';
     const field = 'user_expiration_date';
     const operator = OPERATORS.EQUAL;

--- a/src/QueryBuilder/ResultViewer/DateTimeRender.test.js
+++ b/src/QueryBuilder/ResultViewer/DateTimeRender.test.js
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { formatValueByDataType } from './utils';
+import { DATA_TYPES } from '../../constants/dataTypes';
+
+// This test explicitly validates the divergence between DateType (raw) and DateTimeType (formatted/localized)
+// Given an ISO timestamp in UTC that would date-shift for some timezones, DateTimeType should format via <FormattedDate />
+// Whereas DateType should ignore timezone and just surface the original YYYY-MM-DD provided by the backend.
+
+describe('Date vs DateTime rendering behavior', () => {
+  const isoDateTime = '2024-07-01T12:30:00Z';
+  const rawDate = '2024-07-01';
+
+  test('DateType returns raw date string (no <FormattedDate> wrapping)', () => {
+    const rendered = formatValueByDataType(rawDate, DATA_TYPES.DateType, null);
+
+    expect(typeof rendered).toBe('string');
+    expect(rendered).toBe(rawDate);
+  });
+
+  test('DateTimeType returns a FormattedDate react element localized', () => {
+    const rendered = formatValueByDataType(isoDateTime, DATA_TYPES.DateTimeType, null);
+
+    // Should be a react element (object) not a plain string
+    expect(typeof rendered).toBe('object');
+
+    const { container } = render(<IntlProvider>{rendered}</IntlProvider>);
+
+    // Default locale assumed (en), month/day could vary by environment but generally M/D/YYYY; we defensively match by parts.
+    const text = container.textContent;
+
+    expect(text).toBeTruthy();
+    // Basic assertions: year present and month/day digits present
+    expect(text).toMatch(/2024/);
+  });
+
+  test('DateType trims ISO to date-only if unexpectedly provided full ISO', () => {
+    const rendered = formatValueByDataType(isoDateTime, DATA_TYPES.DateType, null);
+
+    expect(rendered).toBe(rawDate);
+  });
+});

--- a/src/QueryBuilder/ResultViewer/DynamicTable/DynamicTable.test.js
+++ b/src/QueryBuilder/ResultViewer/DynamicTable/DynamicTable.test.js
@@ -93,6 +93,30 @@ describe('DynamicTable component', () => {
       labelAlias: 'Empty date column',
       property: 'emptyDate',
     },
+    {
+      name: 'cool_datetime',
+      dataType: {
+        dataType: 'dateTimeType',
+      },
+      labelAlias: 'Datetime column',
+      property: 'coolDatetime',
+    },
+    {
+      name: 'less_cool_datetime',
+      dataType: {
+        dataType: 'dateTimeType',
+      },
+      labelAlias: 'Datetime column 2',
+      property: 'lessCoolDatetime',
+    },
+    {
+      name: 'empty_datetime',
+      dataType: {
+        dataType: 'dateTimeType',
+      },
+      labelAlias: 'Empty datetime column',
+      property: 'emptyDatetime',
+    },
   ];
 
   it.each(['[]', undefined, null])(
@@ -147,11 +171,11 @@ describe('DynamicTable component', () => {
     expect(falseCell).toBeInTheDocument();
     expect(trueCell.compareDocumentPosition(falseCell)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
 
-    const coolDateCell = getByText('1/1/2021'); // after midnight in EST
-    const lessCoolDateCell = getByText('12/31/2020'); // before midnight in EST
+    const dateCells = Array.from(document.querySelectorAll('td')).filter(td => td.textContent === '2021-01-01');
 
-    expect(coolDateCell).toBeInTheDocument();
-    expect(lessCoolDateCell).toBeInTheDocument();
-    expect(coolDateCell.compareDocumentPosition(lessCoolDateCell)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(dateCells.length).toBeGreaterThanOrEqual(2);
+    // ensure both date columns rendered (duplicate raw dates acceptable)
+    expect(dateCells[0]).toBeInTheDocument();
+    expect(dateCells[1]).toBeInTheDocument();
   });
 });

--- a/src/QueryBuilder/ResultViewer/utils.js
+++ b/src/QueryBuilder/ResultViewer/utils.js
@@ -27,6 +27,19 @@ export const formatValueByDataType = (value, dataType, intl, additionalParams = 
       }
 
     case DATA_TYPES.DateType:
+      // DateType is timezone agnostic; value expected as YYYY-MM-DD. Return as-is (string) so table renders raw/localizable text.
+      // If BE ever sends full ISO, fall back to trimming time part.
+      if (typeof value === 'string') {
+        const dateOnlyMatch = value.match(/^(\d{4}-\d{2}-\d{2})/);
+
+        if (dateOnlyMatch) {
+          return dateOnlyMatch[1];
+        }
+      }
+
+      return value;
+
+    case DATA_TYPES.DateTimeType:
       return <FormattedDate value={value} />;
 
     case DATA_TYPES.JsonbArrayType:

--- a/src/QueryBuilder/ResultViewer/utils.test.js
+++ b/src/QueryBuilder/ResultViewer/utils.test.js
@@ -15,8 +15,11 @@ describe('formatValueByDataType returns correct value', () => {
     ['false', DATA_TYPES.BooleanType, 'ui-plugin-query-builder.options.false'],
 
     ['2024-01-01T12:30:00Z', DATA_TYPES.StringType, '2024-01-01T12:30:00Z'],
-    ['2024-01-01T12:30:00Z', DATA_TYPES.DateType, '1/1/2024'],
-    ['2024-01-01T12:30:00Z', DATA_TYPES.DateType, '1/1/2024'],
+    // DateType: raw YYYY-MM-DD preserved
+    ['2024-01-01', DATA_TYPES.DateType, '2024-01-01'],
+    ['2024-01-1', DATA_TYPES.DateType, '2024-01-1'],
+    // DateTimeType: formatted (locale dependent). Our test env default shows M/D/YYYY
+    ['2024-01-01T12:30:00Z', DATA_TYPES.DateTimeType, '1/1/2024'],
 
     [[], DATA_TYPES.ArrayType, ''],
     [['a'], DATA_TYPES.ArrayType, 'a'],

--- a/src/constants/dataTypes.js
+++ b/src/constants/dataTypes.js
@@ -6,6 +6,7 @@ export const DATA_TYPES = {
   NumberType: 'numberType',
   IntegerType: 'integerType',
   DateType: 'dateType',
+  DateTimeType: 'dateTimeType',
   BooleanType: 'booleanType',
   EnumType: 'enumType',
   ObjectType: 'objectType',

--- a/test/jest/data/entityType.js
+++ b/test/jest/data/entityType.js
@@ -65,7 +65,7 @@ export const entityType = {
       'name': 'user_expiration_date',
       'queryable': true,
       'dataType': {
-        'dataType': 'dateType',
+        'dataType': 'dateTimeType',
       },
       'labelAlias': 'User expiration date',
       'visibleByDefault': true,


### PR DESCRIPTION
This new data type maintains the old behavior of DateType, with regard to time zones. DateType's behavior has been changed so that it disregards the time component (if provided).

## Purpose
This change allows for date-only data types, to avoid confusing or unintuitive behavior related to time zones, where the user selects one date and unexpectedly has it treated as another.

## Approach
This adds support for the new DateTimeType data type. This type maintains the older behavior that was previously associated with DateType. The behavior of the older type has been updated to be time zone agnostic. To do this, all dates of type DateType are handled without a time component (in both how they are displayed in the user-friendly query and what is sent to the FQM API). This is accomplished simply by specifying the UTC time zone and a custom date format in the `Datepicker` component props for this type.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added an appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [X] Code coverage on new code is 80% or greater
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [X] There are no breaking changes in this PR. While this does change the behavior of the plugin for DateType fields, this can be accounted for in the FQM APIs.
