### PR TITLE
[UIPQB-268] Restore 'Select value' placeholder in value dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * [UIPQB-260](https://folio-org.atlassian.net/browse/UIPQB-260) Fix undefined values when editing a query
 * [UIPQB-261](https://folio-org.atlassian.net/browse/UIPQB-261) Add maxColumnWidth support
 * [UIPQB-267](https://folio-org.atlassian.net/browse/UIPQB-267) *BREAKING* Use GET /locale to get tenant language & locale settings
+* [UIPQB-268](https://folio-org.atlassian.net/browse/UIPQB-268) Restore 'Select value' placeholder in value dropdown
 
 ## [2.0.3](https://github.com/folio-org/ui-plugin-query-builder/tree/v2.0.3) (2025-04-18)
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.js
@@ -102,7 +102,7 @@ export const SelectionContainer = ({
 
   const fuzzyFormatter = useCallback(({ option, searchTerm }) => {
     if (!option?.label) {
-      return <OptionSegment />;
+      return null;
     }
 
     if (typeof searchTerm !== 'string' || searchTerm === '') {

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.test.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.test.js
@@ -245,17 +245,4 @@ describe('SelectionContainer', () => {
 
     expect(true).toBe(true);
   });
-
-  it('passes the value placeholder to single-select components', () => {
-    const mockComponent = jest.fn(() => null);
-
-    renderSelectionContainer({
-      component: mockComponent,
-      options: [],
-    });
-
-    const props = mockComponent.mock.calls[0][0];
-
-    expect(props.placeholder).toBe('ui-plugin-query-builder.control.value.placeholder');
-  });
 });

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.test.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.test.js
@@ -126,6 +126,20 @@ describe('SelectionContainer', () => {
     expect(element.props.children).toBe('Apple');
   });
 
+  it('formatter returns null when no selected option is present so the control placeholder can render', () => {
+    const mockComponent = jest.fn(() => null);
+
+    renderSelectionContainer({
+      component: mockComponent,
+      options: [],
+    });
+
+    const props = mockComponent.mock.calls[0][0];
+    const element = props.formatter({ option: undefined });
+
+    expect(element).toBeNull();
+  });
+
   it('formatter returns label when no fuzzysort match', () => {
     const mockComponent = jest.fn(() => null);
 
@@ -230,5 +244,18 @@ describe('SelectionContainer', () => {
     );
 
     expect(true).toBe(true);
+  });
+
+  it('passes the value placeholder to single-select components', () => {
+    const mockComponent = jest.fn(() => null);
+
+    renderSelectionContainer({
+      component: mockComponent,
+      options: [],
+    });
+
+    const props = mockComponent.mock.calls[0][0];
+
+    expect(props.placeholder).toBe('ui-plugin-query-builder.control.value.placeholder');
   });
 });


### PR DESCRIPTION
## Purpose
[UIPQB-268](https://folio-org.atlassian.net/browse/UIPQB-268): Restore 'Select value' placeholder in value dropdown

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?

  - [x] There are no breaking changes in this PR.