### PR TITLE
[UIPQB-271] Remove specific language-field translation logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-plugin-query-builder
 
 ## [3.1.0] IN PROGRESS
+* [UIPQB-271](https://folio-org.atlassian.net/browse/UIPQB-271) Remove specific language-field translation logic
 
 ## [3.0.0](https://github.com/folio-org/ui-plugin-query-builder/tree/v3.0.0) (2026-04-16)
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
@@ -58,7 +58,7 @@ export const RepeatableFields = memo(({ source, setSource, columns, entityTypeId
       },
     ]));
   };
-
+//
   const handleRemove = (index) => {
     if (index === 0) {
       setSource((prevSource) => {

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
@@ -58,7 +58,7 @@ export const RepeatableFields = memo(({ source, setSource, columns, entityTypeId
       },
     ]));
   };
-//
+
   const handleRemove = (index) => {
     if (index === 0) {
       setSource((prevSource) => {

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
@@ -34,9 +34,7 @@ export const getMemoizedValues = ({
   rowField,
   getDataOptions,
 }) => (
-  currentOptions
-    ? currentOptions
-    : getDataOptions(rowField)
+  currentOptions || getDataOptions(rowField)
 );
 
 export const RepeatableFields = memo(({ source, setSource, columns, entityTypeId }) => {

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
@@ -31,13 +31,12 @@ import css from '../QueryBuilderModal.css';
 
 export const getMemoizedValues = ({
   currentOptions,
-  isLanguageField,
   rowField,
   getDataOptions,
 }) => (
-  currentOptions && !isLanguageField
+  currentOptions
     ? currentOptions
-    : getDataOptions(rowField, false, undefined, [], isLanguageField)
+    : getDataOptions(rowField)
 );
 
 export const RepeatableFields = memo(({ source, setSource, columns, entityTypeId }) => {
@@ -97,10 +96,8 @@ export const RepeatableFields = memo(({ source, setSource, columns, entityTypeId
     const memoizedFieldSource = source[index].value.source;
     const memorizedField = fieldOptions.find(o => o.value === rowField);
     const memorizedOperator = source[index].operator.current;
-    const isLanguageField = memoizedFieldSource?.columnName === 'languages' || memorizedField?.source?.columnName === 'languages';
     const memoizedValues = getMemoizedValues({
       currentOptions: source[index].value.options,
-      isLanguageField,
       rowField,
       getDataOptions,
     });

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.test.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.test.js
@@ -1,33 +1,17 @@
 import { getMemoizedValues } from './RepeatableFields';
 
 describe('getMemoizedValues', () => {
-  it('uses cached options for non-language fields', () => {
+  it('uses cached options when they exist', () => {
     const currentOptions = [{ value: 'available', label: 'Available' }];
     const getDataOptions = jest.fn();
 
     expect(getMemoizedValues({
       currentOptions,
-      isLanguageField: false,
       rowField: 'status',
       getDataOptions,
     })).toEqual(currentOptions);
 
     expect(getDataOptions).not.toHaveBeenCalled();
-  });
-
-  it('uses fetched options for language fields even when cached options exist', () => {
-    const currentOptions = [{ value: 'ger', label: 'German' }];
-    const fetchedOptions = [{ value: 'ger', label: 'German [ger]' }];
-    const getDataOptions = jest.fn(() => fetchedOptions);
-
-    expect(getMemoizedValues({
-      currentOptions,
-      isLanguageField: true,
-      rowField: 'instance.languages',
-      getDataOptions,
-    })).toEqual(fetchedOptions);
-
-    expect(getDataOptions).toHaveBeenCalledWith('instance.languages', false, undefined, [], true);
   });
 
   it('uses fetched options when cached options are missing', () => {
@@ -36,11 +20,10 @@ describe('getMemoizedValues', () => {
 
     expect(getMemoizedValues({
       currentOptions: undefined,
-      isLanguageField: false,
       rowField: 'status',
       getDataOptions,
     })).toEqual(fetchedOptions);
 
-    expect(getDataOptions).toHaveBeenCalledWith('status', false, undefined, [], false);
+    expect(getDataOptions).toHaveBeenCalledWith('status');
   });
 });

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -42,8 +42,7 @@ export const getQueryStr = (rows, fieldOptions, intl, timezone, getDataOptions) 
     const field = row[COLUMN_KEYS.FIELD].current;
     const operator = row[COLUMN_KEYS.OPERATOR].current;
     const value = row[COLUMN_KEYS.VALUE].current;
-    const isLanguageField = row[COLUMN_KEYS.VALUE].source?.columnName === 'languages';
-    const labeledValue = getLabeledValue(value, getDataOptions(field, false, undefined, [], isLanguageField));
+    const labeledValue = getLabeledValue(value, getDataOptions(field));
     const builtValue = valueBuilder({ value: labeledValue, field, operator, fieldOptions, intl, timezone });
 
     const queryPiece = `(${findLabelByValue(row[COLUMN_KEYS.FIELD], field)} ${operator} ${builtValue})`;

--- a/src/QueryBuilder/ResultViewer/DynamicTable/DynamicTable.js
+++ b/src/QueryBuilder/ResultViewer/DynamicTable/DynamicTable.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { get } from 'lodash';
 import { useIntl } from 'react-intl';
-import { getNestedValue } from '../utils';
 import css from './DynamicTable.css';
 
 export const DynamicTable = ({ columns = [], values = [], formatter }) => {
@@ -26,7 +26,7 @@ export const DynamicTable = ({ columns = [], values = [], formatter }) => {
             {columns.map((column) => (
               <td key={column.id} style={column.styles}>
                 {formatter(
-                  getNestedValue(row, column.id),
+                  get(row, column.id),
                   column.dataType,
                   undefined,
                   intl,

--- a/src/QueryBuilder/ResultViewer/ResultViewer.test.js
+++ b/src/QueryBuilder/ResultViewer/ResultViewer.test.js
@@ -119,7 +119,7 @@ describe('ResultViewer', () => {
     const limit = 200;
     const changePage = jest.fn();
 
-    it('should format language name shortcuts to full name', async () => {
+    it('should render language values as provided by the backend', async () => {
       render(renderResultViewer({ visibleColumns:
           ['instance.languages', 'user_expiration_date', 'department_names', 'decimal_position', 'user_id'] }));
 
@@ -127,7 +127,7 @@ describe('ResultViewer', () => {
         expect(screen.queryByText('ui-plugin-query-builder.result.inProgress')).not.toBeInTheDocument();
 
         expect(screen.queryByText('Languages')).toBeVisible();
-        expect(screen.queryByText('English | French')).toBeVisible();
+        expect(screen.queryByText('eng | fre')).toBeVisible();
       });
     });
 

--- a/src/QueryBuilder/ResultViewer/helpers.js
+++ b/src/QueryBuilder/ResultViewer/helpers.js
@@ -3,7 +3,6 @@ import { FormattedMessage } from 'react-intl';
 import { formatValueByDataType } from './utils';
 
 const MIN_CONTROLLABLE_WIDTH = 30;
-const INSTANCE_LANGUAGE_FIELDS = new Set(['instance.languages', 'instances.languages']);
 
 export const getTableMetadata = (entityType, forcedVisibleValues, intl) => {
   const defaultColumns = (entityType?.columns?.map((cell) => ({
@@ -49,7 +48,6 @@ export const getTableMetadata = (entityType, forcedVisibleValues, intl) => {
         dataType,
         properties,
         intl,
-        { isInstanceLanguages: INSTANCE_LANGUAGE_FIELDS.has(value) },
       );
     };
 

--- a/src/QueryBuilder/ResultViewer/helpers.test.js
+++ b/src/QueryBuilder/ResultViewer/helpers.test.js
@@ -143,7 +143,6 @@ describe('getTableMetadata.formatter (rendered output)', () => {
       'numberType',
       undefined,
       intl,
-      { isInstanceLanguages: false },
     );
     expect(screen.getByText('formatted-value')).toBeInTheDocument();
   });
@@ -168,12 +167,11 @@ describe('getTableMetadata.formatter (rendered output)', () => {
       'numberType',
       undefined,
       intl,
-      { isInstanceLanguages: false },
     );
     expect(screen.getByText('formatted-value')).toBeInTheDocument();
   });
 
-  it('sets isInstanceLanguages=true only for "instance.languages"', () => {
+  it('passes instance languages through to the formatter unchanged', () => {
     const entityType = {
       columns: [
         {
@@ -193,7 +191,6 @@ describe('getTableMetadata.formatter (rendered output)', () => {
       'arrayType',
       undefined,
       intl,
-      { isInstanceLanguages: true },
     );
     expect(screen.getByText('formatted-value')).toBeInTheDocument();
   });

--- a/src/QueryBuilder/ResultViewer/utils.js
+++ b/src/QueryBuilder/ResultViewer/utils.js
@@ -11,6 +11,32 @@ export const getNestedValue = (obj, path) => {
   return get(obj, path);
 };
 
+export const formatLanguagesForDisplay = (languages = [], intl) => {
+  const formattedOptions = languages.map((code) => {
+    const formattedLabel = formattedLanguageName(code, intl);
+    const label = formattedLabel && formattedLabel !== 'Undetermined'
+      ? formattedLabel
+      : code;
+
+    return { code, label };
+  });
+  const labelCounts = formattedOptions.reduce((counts, item) => {
+    counts.set(item.label, (counts.get(item.label) || 0) + 1);
+    return counts;
+  }, new Map());
+
+  return formattedOptions
+    .map((item) => (
+      labelCounts.get(item.label) > 1
+        ? intl.formatMessage(
+          { id: 'ui-plugin-query-builder.control.value.languageDisambiguated' },
+          { label: item.label, code: item.code },
+        )
+        : item.label
+    ))
+    .toSorted((aa, bb) => aa.localeCompare(bb));
+};
+
 export const formatValueByDataType = (value, dataType, properties, intl, additionalParams = {}) => {
   if (value === undefined || value === null) {
     return '';
@@ -69,7 +95,7 @@ export const formatValueByDataType = (value, dataType, properties, intl, additio
     case DATA_TYPES.JsonbArrayType:
     case DATA_TYPES.ArrayType:
       if (additionalParams?.isInstanceLanguages) {
-        return value.map((lang) => formattedLanguageName(lang, intl)).join(' | ');
+        return formatLanguagesForDisplay(value, intl).join(' | ');
       }
 
       return value.join(' | ');

--- a/src/QueryBuilder/ResultViewer/utils.js
+++ b/src/QueryBuilder/ResultViewer/utils.js
@@ -9,6 +9,37 @@ export const getNestedValue = (obj, path) => {
   return get(obj, path);
 };
 
+const formatBooleanValue = (value) => {
+  // booleans may be returned as true booleans, or strings 'true' or 'false'
+  if (typeof value === 'string') {
+    return value === 'true' ? (
+      <FormattedMessage id="ui-plugin-query-builder.options.true" />
+    ) : (
+      <FormattedMessage id="ui-plugin-query-builder.options.false" />
+    );
+  }
+
+  return value ? (
+    <FormattedMessage id="ui-plugin-query-builder.options.true" />
+  ) : (
+    <FormattedMessage id="ui-plugin-query-builder.options.false" />
+  );
+};
+
+const formatDateValue = (value) => {
+  // DateType is timezone agnostic; value expected as YYYY-MM-DD. Return as-is (string) so table renders raw/localizable text.
+  // If BE ever sends full ISO, fall back to trimming time part.
+  if (typeof value === 'string') {
+    const dateOnlyMatch = value.match(/^(\d{4}-\d{2}-\d{2})/);
+
+    if (dateOnlyMatch) {
+      return dateOnlyMatch[1];
+    }
+  }
+
+  return value;
+};
+
 export const formatValueByDataType = (value, dataType, properties, intl) => {
   if (value === undefined || value === null) {
     return '';
@@ -33,33 +64,10 @@ export const formatValueByDataType = (value, dataType, properties, intl) => {
 
   switch (dataType) {
     case DATA_TYPES.BooleanType:
-      // booleans may be returned as true booleans, or strings 'true' or 'false'
-      if (typeof value === 'string') {
-        return value === 'true' ? (
-          <FormattedMessage id="ui-plugin-query-builder.options.true" />
-        ) : (
-          <FormattedMessage id="ui-plugin-query-builder.options.false" />
-        );
-      } else {
-        return value ? (
-          <FormattedMessage id="ui-plugin-query-builder.options.true" />
-        ) : (
-          <FormattedMessage id="ui-plugin-query-builder.options.false" />
-        );
-      }
+      return formatBooleanValue(value);
 
     case DATA_TYPES.DateType:
-      // DateType is timezone agnostic; value expected as YYYY-MM-DD. Return as-is (string) so table renders raw/localizable text.
-      // If BE ever sends full ISO, fall back to trimming time part.
-      if (typeof value === 'string') {
-        const dateOnlyMatch = value.match(/^(\d{4}-\d{2}-\d{2})/);
-
-        if (dateOnlyMatch) {
-          return dateOnlyMatch[1];
-        }
-      }
-
-      return value;
+      return formatDateValue(value);
 
     case DATA_TYPES.DateTimeType:
       return <FormattedDate value={value} />;

--- a/src/QueryBuilder/ResultViewer/utils.js
+++ b/src/QueryBuilder/ResultViewer/utils.js
@@ -1,13 +1,8 @@
 import React from 'react';
 import { FormattedDate, FormattedMessage } from 'react-intl';
-import { get } from 'lodash';
 
 import { DATA_TYPES } from '../../constants/dataTypes';
 import { DynamicTable } from './DynamicTable';
-
-export const getNestedValue = (obj, path) => {
-  return get(obj, path);
-};
 
 const formatBooleanValue = (value) => {
   // booleans may be returned as true booleans, or strings 'true' or 'false'

--- a/src/QueryBuilder/ResultViewer/utils.js
+++ b/src/QueryBuilder/ResultViewer/utils.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { FormattedDate, FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 
-import { formattedLanguageName } from '@folio/stripes/components';
-
 import { DATA_TYPES } from '../../constants/dataTypes';
 import { DynamicTable } from './DynamicTable';
 
@@ -11,33 +9,7 @@ export const getNestedValue = (obj, path) => {
   return get(obj, path);
 };
 
-export const formatLanguagesForDisplay = (languages = [], intl) => {
-  const formattedOptions = languages.map((code) => {
-    const formattedLabel = formattedLanguageName(code, intl);
-    const label = formattedLabel && formattedLabel !== 'Undetermined'
-      ? formattedLabel
-      : code;
-
-    return { code, label };
-  });
-  const labelCounts = formattedOptions.reduce((counts, item) => {
-    counts.set(item.label, (counts.get(item.label) || 0) + 1);
-    return counts;
-  }, new Map());
-
-  return formattedOptions
-    .map((item) => (
-      labelCounts.get(item.label) > 1
-        ? intl.formatMessage(
-          { id: 'ui-plugin-query-builder.control.value.languageDisambiguated' },
-          { label: item.label, code: item.code },
-        )
-        : item.label
-    ))
-    .toSorted((aa, bb) => aa.localeCompare(bb));
-};
-
-export const formatValueByDataType = (value, dataType, properties, intl, additionalParams = {}) => {
+export const formatValueByDataType = (value, dataType, properties, intl) => {
   if (value === undefined || value === null) {
     return '';
   }
@@ -94,10 +66,6 @@ export const formatValueByDataType = (value, dataType, properties, intl, additio
 
     case DATA_TYPES.JsonbArrayType:
     case DATA_TYPES.ArrayType:
-      if (additionalParams?.isInstanceLanguages) {
-        return formatLanguagesForDisplay(value, intl).join(' | ');
-      }
-
       return value.join(' | ');
 
     case DATA_TYPES.NumberType:

--- a/src/QueryBuilder/ResultViewer/utils.test.js
+++ b/src/QueryBuilder/ResultViewer/utils.test.js
@@ -2,17 +2,7 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { DATA_TYPES } from '../../constants/dataTypes';
-import { findLabelByValue, formatLanguagesForDisplay, formatValueByDataType } from './utils';
-
-jest.mock('@folio/stripes/components', () => ({
-  ...jest.requireActual('@folio/stripes/components'),
-  formattedLanguageName: jest.fn((value) => ({
-    de: 'German',
-    ger: 'German',
-    eng: 'English',
-    zzz: 'Undetermined',
-  }[value] || value)),
-}));
+import { findLabelByValue, formatValueByDataType } from './utils';
 
 jest.mock('./DynamicTable/DynamicTable', () => ({
   __esModule: true,
@@ -129,30 +119,6 @@ describe('formatValueByDataType returns correct value', () => {
       { id: 't1', name: 'alpha', active: true },
       { id: 't2', name: 'beta', active: false },
     ]);
-  });
-});
-
-describe('formatLanguagesForDisplay', () => {
-  const intl = {
-    formatMessage: ({ id }, values = {}) => {
-      if (id === 'ui-plugin-query-builder.control.value.languageDisambiguated') {
-        return `${values.label} [${values.code}]`;
-      }
-
-      return id;
-    },
-  };
-
-  it('disambiguates clashing formatted language labels and sorts by final label', () => {
-    expect(formatLanguagesForDisplay(['de', 'ger', 'eng'], intl)).toEqual([
-      'English',
-      'German [de]',
-      'German [ger]',
-    ]);
-  });
-
-  it('falls back to the raw code for unknown language labels', () => {
-    expect(formatLanguagesForDisplay(['zzz'], intl)).toEqual(['zzz']);
   });
 });
 

--- a/src/QueryBuilder/ResultViewer/utils.test.js
+++ b/src/QueryBuilder/ResultViewer/utils.test.js
@@ -2,7 +2,17 @@ import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { DATA_TYPES } from '../../constants/dataTypes';
-import { findLabelByValue, formatValueByDataType } from './utils';
+import { findLabelByValue, formatLanguagesForDisplay, formatValueByDataType } from './utils';
+
+jest.mock('@folio/stripes/components', () => ({
+  ...jest.requireActual('@folio/stripes/components'),
+  formattedLanguageName: jest.fn((value) => ({
+    de: 'German',
+    ger: 'German',
+    eng: 'English',
+    zzz: 'Undetermined',
+  }[value] || value)),
+}));
 
 jest.mock('./DynamicTable/DynamicTable', () => ({
   __esModule: true,
@@ -119,6 +129,30 @@ describe('formatValueByDataType returns correct value', () => {
       { id: 't1', name: 'alpha', active: true },
       { id: 't2', name: 'beta', active: false },
     ]);
+  });
+});
+
+describe('formatLanguagesForDisplay', () => {
+  const intl = {
+    formatMessage: ({ id }, values = {}) => {
+      if (id === 'ui-plugin-query-builder.control.value.languageDisambiguated') {
+        return `${values.label} [${values.code}]`;
+      }
+
+      return id;
+    },
+  };
+
+  it('disambiguates clashing formatted language labels and sorts by final label', () => {
+    expect(formatLanguagesForDisplay(['de', 'ger', 'eng'], intl)).toEqual([
+      'English',
+      'German [de]',
+      'German [ger]',
+    ]);
+  });
+
+  it('falls back to the raw code for unknown language labels', () => {
+    expect(formatLanguagesForDisplay(['zzz'], intl)).toEqual(['zzz']);
   });
 });
 

--- a/src/QueryBuilder/ResultViewer/utils.test.js
+++ b/src/QueryBuilder/ResultViewer/utils.test.js
@@ -120,6 +120,10 @@ describe('formatValueByDataType returns correct value', () => {
       { id: 't2', name: 'beta', active: false },
     ]);
   });
+
+  it('returns non-string DateType values unchanged', () => {
+    expect(formatValueByDataType(12345, DATA_TYPES.DateType, null, null)).toBe(12345);
+  });
 });
 
 describe('findLabelByValue', () => {

--- a/src/hooks/useDataOptions.js
+++ b/src/hooks/useDataOptions.js
@@ -1,6 +1,4 @@
 import { useCallback, useState } from 'react';
-import { formattedLanguageName } from '@folio/stripes/components';
-import { useIntl } from 'react-intl';
 import { ORGANIZATIONS_TYPES } from '../constants/dataTypes';
 
 function getUniqueValues(a, b) {
@@ -13,44 +11,7 @@ function getUniqueValues(a, b) {
 }
 
 export function useDataOptions({ getParamsSource, getOrganizations }) {
-  const intl = useIntl();
   const [dataOptions, setDataOptions] = useState({});
-
-  const formatLanguageOptions = useCallback((data, shouldFormat) => {
-    if (!shouldFormat || !Array.isArray(data)) {
-      return data;
-    }
-
-    const formattedOptions = data.map((item) => {
-      const formattedLabel = formattedLanguageName(item.value, intl);
-      const fallbackLabel = item.label || item.value;
-      const label = formattedLabel && formattedLabel !== 'Undetermined'
-        ? formattedLabel
-        : fallbackLabel;
-
-      return {
-        value: item.value,
-        label,
-      };
-    });
-    const labelCounts = formattedOptions.reduce((counts, item) => {
-      counts.set(item.label, (counts.get(item.label) || 0) + 1);
-
-      return counts;
-    }, new Map());
-
-    return formattedOptions
-      .map((item) => ({
-        ...item,
-        label: labelCounts.get(item.label) > 1
-          ? intl.formatMessage(
-            { id: 'ui-plugin-query-builder.control.value.languageDisambiguated' },
-            { label: item.label, code: item.value },
-          )
-          : item.label,
-      }))
-      .toSorted((aa, bb) => aa.label.localeCompare(bb.label));
-  }, [intl]);
 
   // helper methods to prevent redundant digging through our raw dataOptions
   const getDataOptions = useCallback(
@@ -59,14 +20,13 @@ export function useDataOptions({ getParamsSource, getOrganizations }) {
       allowPromises = false,
       fetchPromise = undefined,
       fetchIfValuesMissing = [],
-      shouldFormatLanguages = false,
     ) => {
       if (
         Array.isArray(dataOptions[field]) &&
                 // check that all specially requested values are present
                 fetchIfValuesMissing.every((v) => !!dataOptions[field].find((o) => o.value === v))
       ) {
-        return formatLanguageOptions(dataOptions[field], shouldFormatLanguages);
+        return dataOptions[field];
       }
 
       // only return promises if requested, to prevent non-async code from exploding here
@@ -97,19 +57,17 @@ export function useDataOptions({ getParamsSource, getOrganizations }) {
         return promise;
       }
 
-      return formatLanguageOptions(dataOptions[field] ?? [], shouldFormatLanguages);
+      return dataOptions[field] ?? [];
     },
-    [dataOptions, formatLanguageOptions],
+    [dataOptions],
   );
 
   const getDataOptionsWithFetching = useCallback(
     // usedIds are only for organization sources
     // `originalEntityTypeId` is the entityTypeId the user is building the query against
     (fieldName, source, searchValue, usedIds, originalEntityTypeId) => {
-      const isLanguageField = source?.columnName === 'languages';
-
       if (!source) {
-        return getDataOptions(fieldName, false, undefined, [], isLanguageField);
+        return getDataOptions(fieldName);
       } else if (ORGANIZATIONS_TYPES.includes(source.name)) {
         return getDataOptions(
           fieldName,
@@ -131,7 +89,6 @@ export function useDataOptions({ getParamsSource, getOrganizations }) {
               return results.flat();
             },
           usedIds,
-          isLanguageField,
         );
       } else {
         // If the entityType isn't known yet, don't attempt value fetching
@@ -148,7 +105,6 @@ export function useDataOptions({ getParamsSource, getOrganizations }) {
             searchValue,
           }).then((data) => data?.content),
           [],
-          isLanguageField,
         );
       }
     },

--- a/src/hooks/useDataOptions.test.js
+++ b/src/hooks/useDataOptions.test.js
@@ -1,31 +1,8 @@
-import { useIntl } from 'react-intl';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useDataOptions } from './useDataOptions';
 import { ORGANIZATIONS_TYPES } from '../constants/dataTypes';
 
-jest.mock('@folio/stripes/components', () => ({
-  ...jest.requireActual('@folio/stripes/components'),
-  formattedLanguageName: jest.fn((value) => ({
-    de: 'German',
-    ger: 'German',
-    eng: 'English',
-    zzz: 'Undetermined',
-  }[value] || value)),
-}));
-
 describe('useDataOptions', () => {
-  beforeEach(() => {
-    useIntl.mockReturnValue({
-      formatMessage: ({ id }, values = {}) => {
-        if (id === 'ui-plugin-query-builder.control.value.languageDisambiguated') {
-          return `${values.label} [${values.code}]`;
-        }
-
-        return id;
-      },
-    });
-  });
-
   describe('getDataOptions', () => {
     it('returns empty array for getting unknown fields', () => {
       const { result } = renderHook(() => useDataOptions({}));
@@ -99,53 +76,6 @@ describe('useDataOptions', () => {
       ]));
     });
 
-    it('disambiguates clashing formatted language labels', async () => {
-      const { result, rerender } = renderHook(() => useDataOptions({}));
-
-      const options = [
-        { value: 'de', label: 'de' },
-        { value: 'ger', label: 'German' },
-        { value: 'eng', label: 'English' },
-      ];
-
-      result.current.getDataOptions('languages', true, () => Promise.resolve(options), [], true);
-
-      rerender();
-
-      await waitFor(() => expect(result.current.getDataOptions('languages', false, undefined, [], true)).toEqual([
-        { value: 'eng', label: 'English' },
-        { value: 'de', label: 'German [de]' },
-        { value: 'ger', label: 'German [ger]' },
-      ]));
-    });
-
-    it('falls back to the raw code when a language code is unknown', async () => {
-      const { result, rerender } = renderHook(() => useDataOptions({}));
-
-      result.current.getDataOptions('languages', true, () => Promise.resolve([
-        { value: 'zzz', label: 'zzz' },
-      ]), [], true);
-
-      rerender();
-
-      await waitFor(() => expect(result.current.getDataOptions('languages', false, undefined, [], true)).toEqual([
-        { value: 'zzz', label: 'zzz' },
-      ]));
-    });
-
-    it('falls back to the raw code when a language code is unknown and no label is provided', async () => {
-      const { result, rerender } = renderHook(() => useDataOptions({}));
-
-      result.current.getDataOptions('languages', true, () => Promise.resolve([
-        { value: 'zzz' },
-      ]), [], true);
-
-      rerender();
-
-      await waitFor(() => expect(result.current.getDataOptions('languages', false, undefined, [], true)).toEqual([
-        { value: 'zzz', label: 'zzz' },
-      ]));
-    });
   });
 
   describe('getDataOptionsWithFetching', () => {

--- a/src/hooks/useDataOptions.test.js
+++ b/src/hooks/useDataOptions.test.js
@@ -75,7 +75,6 @@ describe('useDataOptions', () => {
         { value: 'foo', label: 'foo' },
       ]));
     });
-
   });
 
   describe('getDataOptionsWithFetching', () => {

--- a/translations/ui-plugin-query-builder/en.json
+++ b/translations/ui-plugin-query-builder/en.json
@@ -25,7 +25,6 @@
   "control.info.separateValues": "Separate multiple values with a comma.",
   "control.selection.placeholder": "Select field",
   "control.value.placeholder": "Select value",
-  "control.value.languageDisambiguated": "{label} [{code}]",
   "control.value.placeholder.organization": "Use the “Organization look-up” below to add values",
   "control.value.placeholder.donor_organization": "Use the “Donor organization look-up” below to add values",
   "control.operator.placeholder": "Select operator",


### PR DESCRIPTION
## Purpose
[UIPQB-271](https://folio-org.atlassian.net/browse/UIPQB-271) part 2. Long story short, we're removing all language field handling from the query builder and doing it all in FQM. Then the QB and list exports become simple consumers, without having special logic for language fields in 3 different projects.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.
