### PR TITLE
UIPQB-279 Support fields with valueSourceApi but no source property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-plugin-query-builder
 
-## [3.1.0] IN PROGRESS
+## [3.0.2] IN PROGRESS
+* [UIPQB-279](https://folio-org.atlassian.net/browse/UIPQB-279) Add support for fields containing a valueSourceApi property without a source property
 
 ## [3.0.1](https://github.com/folio-org/ui-plugin-query-builder/tree/v3.0.1) (2026-05-13)
 * [UIPQB-271](https://folio-org.atlassian.net/browse/UIPQB-271) Disambiguate duplicate language labels in UI

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.js
@@ -17,10 +17,30 @@ import {
 } from '../../../../constants/dataTypes';
 import { OPERATORS } from '../../../../constants/operators';
 import useTenantTimezone from '../../../../hooks/useTenantTimezone';
-import { staticBooleanOptions } from '../../helpers/selectOptions';
+import { hasValueOptions, staticBooleanOptions } from '../../helpers/selectOptions';
 import { SelectionContainer } from '../SelectionContainer/SelectionContainer';
 
 import css from '../../../QueryBuilder.css';
+
+const fallbackInputPropsByDataType = {
+  [DATA_TYPES.IntegerType]: {
+    type: 'number',
+    textClass: css.NumberInput,
+  },
+  [DATA_TYPES.NumberType]: {
+    type: 'number',
+    textClass: css.NumberInput,
+  },
+};
+
+const getFallbackInputValue = (inputValue) => {
+  if (!Array.isArray(inputValue)) return inputValue;
+
+  return inputValue
+    .map((item) => item?.value ?? item?.id ?? item?.label ?? item)
+    .filter((item) => item !== undefined && item !== null && typeof item !== 'object')
+    .join(', ');
+};
 
 function getOrganizationPluginButton(source, multi, onChange, value, index) {
   if (!ORGANIZATIONS_TYPES.includes(source?.name)) {
@@ -86,6 +106,7 @@ export const DataTypeInput = ({
   index,
   operator,
   source,
+  valueSourceApi,
   fieldName,
   value,
   entityTypeId,
@@ -94,11 +115,11 @@ export const DataTypeInput = ({
   const isInRelatedOperator = [OPERATORS.IN, OPERATORS.NOT_IN].includes(operator);
   const isEqualRelatedOperator = [OPERATORS.EQUAL, OPERATORS.NOT_EQUAL].includes(operator);
   const isEmptyRelatedOperator = [OPERATORS.EMPTY].includes(operator);
-  const hasSourceOrValues = source || availableValues;
+  const hasSourceOrValues = hasValueOptions({ values: availableValues, source, valueSourceApi });
 
   const { tenantTimezone: timezone } = useTenantTimezone();
 
-  const textControl = ({ testId, type = 'text', value: inputValue, textClass }) => {
+  const textControl = ({ dataTestId, type = 'text', value: inputValue, textClass }) => {
     const onKeyDown = (event) => {
       // prevent typing e, +, - in number type
       if (type === 'number' && (event.keyCode === 69 || event.keyCode === 187 || event.keyCode === 189)) {
@@ -108,7 +129,7 @@ export const DataTypeInput = ({
 
     return (
       <TextField
-        data-testid={testId}
+        data-testid={dataTestId}
         onChange={(e) => onChange(e.target.value, index, COLUMN_KEYS.VALUE)}
         onKeyDown={onKeyDown}
         type={type}
@@ -127,15 +148,25 @@ export const DataTypeInput = ({
     />
   );
 
+  const fallbackInputControl = (inputValue) => {
+    return textControl({
+      dataTestId: `data-input-text-${dataType}`,
+      value: getFallbackInputValue(inputValue),
+      ...fallbackInputPropsByDataType[dataType],
+    });
+  };
+
   const selectControl = ({ testId, value: inputValue }) => (
     <SelectionContainer
       fieldName={fieldName}
       component={Selection}
       source={source}
+      valueSourceApi={valueSourceApi}
       entityTypeId={entityTypeId}
       testId={testId}
       availableValues={availableValues}
       value={inputValue}
+      fallback={fallbackInputControl(inputValue)}
       onChange={(selectedValue) => onChange(selectedValue, index, COLUMN_KEYS.VALUE)}
       {...rest}
     />
@@ -148,12 +179,14 @@ export const DataTypeInput = ({
       testId={testId}
       component={MultiSelection}
       source={source}
+      valueSourceApi={valueSourceApi}
       entityTypeId={entityTypeId}
       availableValues={availableValues}
       onChange={(selectedItems) => onChange(selectedItems, index, COLUMN_KEYS.VALUE)}
       isMulti
       emptyMessage={emptyMessage}
       value={inputValue}
+      fallback={fallbackInputControl(inputValue)}
       {...rest}
     />
   );
@@ -218,7 +251,7 @@ export const DataTypeInput = ({
       );
     }
 
-    return textControl({ testId: `data-input-text-${testIdPostfix}`, value });
+    return textControl({ dataTestId: `data-input-text-${testIdPostfix}`, value });
   };
 
   const numericTypeControls = () => {
@@ -248,7 +281,7 @@ export const DataTypeInput = ({
       </>
     ) : (
       <div className={className}>
-        {textControl({ testId: 'data-input-text-openUUIDType', value })}
+        {textControl({ dataTestId: 'data-input-text-openUUIDType', value })}
       </div>
     );
   };
@@ -287,10 +320,10 @@ export const DataTypeInput = ({
       return booleanTypeControls();
 
     case DATA_TYPES.RangedUUIDType:
-      return textControl({ testId: 'data-input-text-rangedUUIDType', value });
+      return textControl({ dataTestId: 'data-input-text-rangedUUIDType', value });
 
     case DATA_TYPES.StringUUIDType:
-      return textControl({ testId: 'data-input-text-stringUUIDType', value });
+      return textControl({ dataTestId: 'data-input-text-stringUUIDType', value });
 
     case DATA_TYPES.DateType:
       return datePickerControl();
@@ -305,7 +338,7 @@ export const DataTypeInput = ({
       return enumTypeControls();
 
     default:
-      return textControl({ testId: 'data-input-text-default', value });
+      return textControl({ dataTestId: 'data-input-text-default', value });
   }
 };
 
@@ -321,6 +354,7 @@ DataTypeInput.propTypes = {
     entityTypeId: PropTypes.string,
     columnName: PropTypes.string,
   }),
+  valueSourceApi: PropTypes.shape({}),
   value: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.bool,

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.test.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/DataTypeInput/DataTypeInput.test.js
@@ -7,6 +7,7 @@ import { DataTypeInput } from './DataTypeInput';
 import { DATA_TYPES } from '../../../../constants/dataTypes';
 import { OPERATORS } from '../../../../constants/operators';
 import { RootContext } from '../../../../context/RootContext';
+import { DATA_OPTIONS_LOAD_FAILED } from '../../../../hooks/useDataOptions';
 
 jest.mock('@folio/stripes/core', () => ({
   ...jest.requireActual('@folio/stripes/core'),
@@ -38,16 +39,18 @@ const renderDataTypeInput = ({
   dataType,
   operator,
   source,
+  valueSourceApi,
   availableValues,
   value,
+  getDataOptionsWithFetching = () => [
+    { label: 'Available', value: 'available' },
+    { label: 'Checked out', value: 'checked' },
+  ],
 }) => render(
   <Intl>
     <RootContext.Provider
       value={{
-        getDataOptionsWithFetching: () => [
-          { label: 'Available', value: 'available' },
-          { label: 'Checked out', value: 'checked' },
-        ],
+        getDataOptionsWithFetching,
       }}
     >
       <QueryClientProvider client={queryClient}>
@@ -56,6 +59,7 @@ const renderDataTypeInput = ({
           dataType={dataType}
           operator={operator}
           source={source}
+          valueSourceApi={valueSourceApi}
           availableValues={availableValues}
           getParamsSource={noop}
           value={value}
@@ -154,6 +158,13 @@ const arr = [
     source: mockSource,
   },
   {
+    dataType: DATA_TYPES.StringType,
+    operator: OPERATORS.EQUAL,
+    componentTestId: 'data-input-select-single-stringType',
+    onChange: jest.fn(),
+    valueSourceApi: { path: '/value-source-api' },
+  },
+  {
     dataType: DATA_TYPES.DateType,
     operator: OPERATORS.GREATER_THAN,
     componentTestId: 'data-input-dateType',
@@ -225,6 +236,7 @@ describe('DataTypeInput', () => {
     text,
     onChange,
     source,
+    valueSourceApi,
     availableValues,
     value,
     expectedOnChangeArgs,
@@ -233,7 +245,7 @@ describe('DataTypeInput', () => {
       const {
         queryByTestId,
         queryByText,
-      } = renderDataTypeInput({ dataType, operator, onChange, source, availableValues, value });
+      } = renderDataTypeInput({ dataType, operator, onChange, source, valueSourceApi, availableValues, value });
       const el = queryByTestId(componentTestId || '') || queryByText(text || '');
 
       await waitFor(() => {
@@ -259,6 +271,51 @@ describe('DataTypeInput', () => {
       }
     });
   }
+});
+
+describe('DataTypeInput source fetch failures', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('falls back to free text when valueSourceApi options fail to load', async () => {
+    const { findByTestId, queryByTestId } = renderDataTypeInput({
+      dataType: DATA_TYPES.StringType,
+      operator: OPERATORS.EQUAL,
+      valueSourceApi: { path: '/value-source-api' },
+      getDataOptionsWithFetching: () => DATA_OPTIONS_LOAD_FAILED,
+    });
+
+    expect(await findByTestId('data-input-text-stringType')).toBeVisible();
+    expect(queryByTestId('data-input-select-single-stringType')).not.toBeInTheDocument();
+  });
+
+  it('falls back to free text for select-only controls when options fail to load', async () => {
+    const { findByTestId, queryByTestId } = renderDataTypeInput({
+      dataType: DATA_TYPES.EnumType,
+      operator: OPERATORS.EQUAL,
+      valueSourceApi: { path: '/value-source-api' },
+      getDataOptionsWithFetching: () => DATA_OPTIONS_LOAD_FAILED,
+    });
+
+    expect(await findByTestId('data-input-text-enumType')).toBeVisible();
+    expect(queryByTestId('data-input-select-arrayType')).not.toBeInTheDocument();
+  });
+
+  it('normalizes multi-select fallback values for free text entry', async () => {
+    const { findByTestId } = renderDataTypeInput({
+      dataType: DATA_TYPES.StringType,
+      operator: OPERATORS.IN,
+      valueSourceApi: { path: '/value-source-api' },
+      value: [
+        { value: 'value1', label: 'Label 1' },
+        { value: 'value2', label: 'Label 2' },
+      ],
+      getDataOptionsWithFetching: () => DATA_OPTIONS_LOAD_FAILED,
+    });
+
+    expect(await findByTestId('data-input-text-stringType')).toHaveValue('value1, value2');
+  });
 });
 
 describe('DataTypeInput with organization Pluggable', () => {

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
@@ -21,6 +21,7 @@ import {
   getFieldOptions,
   getFilteredOptions,
   getOperatorOptions,
+  hasValueOptions,
   REPEATABLE_FIELD_DELIMITER,
   sourceTemplate,
 } from '../../helpers/selectOptions';
@@ -92,6 +93,7 @@ export const RepeatableFields = memo(({ source, setSource, columns, entityTypeId
     const rowField = source[index].field.current;
     const memorizedFieldDataType = source[index].field.dataType;
     const memoizedFieldSource = source[index].value.source;
+    const memoizedFieldValueSourceApi = source[index].value.valueSourceApi;
     const memorizedField = fieldOptions.find(o => o.value === rowField);
     const memorizedOperator = source[index].operator.current;
     const memoizedValues = getMemoizedValues({
@@ -112,7 +114,7 @@ export const RepeatableFields = memo(({ source, setSource, columns, entityTypeId
           [COLUMN_KEYS.OPERATOR]: {
             options: getOperatorOptions({
               dataType: field.dataType,
-              hasSourceOrValues: field.values || field.source,
+              hasSourceOrValues: hasValueOptions(field),
               isFromNestedField: field.value.includes(REPEATABLE_FIELD_DELIMITER),
               intl,
             }),
@@ -121,6 +123,7 @@ export const RepeatableFields = memo(({ source, setSource, columns, entityTypeId
           [COLUMN_KEYS.VALUE]: {
             options: field.values,
             source: field.source,
+            valueSourceApi: field.valueSourceApi,
             current: '',
           },
         };
@@ -131,8 +134,10 @@ export const RepeatableFields = memo(({ source, setSource, columns, entityTypeId
           [COLUMN_KEYS.VALUE]: {
             options: memorizedField.values,
             source: memorizedField.source,
+            valueSourceApi: memorizedField.valueSourceApi,
             current: retainValueOnOperatorChange({
               source: memoizedFieldSource,
+              valueSourceApi: memoizedFieldValueSourceApi,
               dataType: memorizedFieldDataType,
               operator: memorizedOperator,
               newOperator: value,
@@ -243,6 +248,7 @@ export const RepeatableFields = memo(({ source, setSource, columns, entityTypeId
                     index={index}
                     availableValues={row.value.options}
                     source={row.value.source}
+                    valueSourceApi={row.value.valueSourceApi}
                     operator={row.operator.current}
                     onChange={handleChange}
                     data-testid={`input-value-${index}`}

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.js
@@ -7,6 +7,7 @@ import { Loading, OptionSegment } from '@folio/stripes/components';
 
 import { RootContext } from '../../../../context/RootContext';
 import { ORGANIZATIONS_TYPES } from '../../../../constants/dataTypes';
+import { isDataOptionsLoadFailure } from '../../../../hooks/useDataOptions';
 
 export const SelectionContainer = ({
   fieldName,
@@ -16,9 +17,11 @@ export const SelectionContainer = ({
   isMulti,
   onChange,
   source,
+  valueSourceApi,
   entityTypeId,
   testId,
   emptyMessage,
+  fallback,
   value,
   ...rest
 }) => {
@@ -57,7 +60,14 @@ export const SelectionContainer = ({
   };
 
   const usedIds = (Array.isArray(value) ? value : [value]).map(item => item?.value || item).filter(Boolean);
-  const optionsPromise = getDataOptionsWithFetching(fieldName, source, searchValue, usedIds, entityTypeId);
+  const optionsPromise = getDataOptionsWithFetching(
+    fieldName,
+    source,
+    searchValue,
+    usedIds,
+    entityTypeId,
+    valueSourceApi,
+  );
 
   useEffect(() => {
     if (pendingSearchRef.current !== searchValue) {
@@ -141,6 +151,8 @@ export const SelectionContainer = ({
     if (onChange) onChange(selectedValue);
   };
 
+  if (isDataOptionsLoadFailure(optionsPromise)) return fallback ?? null;
+
   if (!Array.isArray(optionsPromise)) return <Loading size="large" />;
 
   const filterProps = isMulti
@@ -173,7 +185,9 @@ SelectionContainer.propTypes = {
   onChange: PropTypes.func,
   index: PropTypes.number,
   source: PropTypes.shape({}),
+  valueSourceApi: PropTypes.shape({}),
   availableValues: PropTypes.arrayOf(PropTypes.shape({})),
+  fallback: PropTypes.node,
   emptyMessage: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.node,

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.test.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import Intl from '../../../../../test/jest/__mock__/intlProvider.mock';
 import { RootContext } from '../../../../context/RootContext';
+import { DATA_OPTIONS_LOAD_FAILED } from '../../../../hooks/useDataOptions';
 import { SelectionContainer } from './SelectionContainer';
 
 const renderSelectionContainer = ({
@@ -11,12 +12,15 @@ const renderSelectionContainer = ({
   value,
   options = [],
   source,
+  valueSourceApi,
+  fallback,
+  getDataOptionsWithFetching = () => options,
 } = {}) => {
   return render(
     <Intl>
       <RootContext.Provider
         value={{
-          getDataOptionsWithFetching: () => options,
+          getDataOptionsWithFetching,
         }}
       >
         <SelectionContainer
@@ -27,6 +31,8 @@ const renderSelectionContainer = ({
           availableValues={availableValues}
           value={value}
           source={source}
+          valueSourceApi={valueSourceApi}
+          fallback={fallback}
         />
       </RootContext.Provider>
     </Intl>,
@@ -48,6 +54,16 @@ describe('SelectionContainer', () => {
     );
 
     expect(container.querySelector('.spinner')).toBeInTheDocument();
+  });
+
+  it('renders fallback when options failed to load', () => {
+    const { getByTestId } = renderSelectionContainer({
+      component: jest.fn(() => null),
+      fallback: <div data-testid="fallback-input" />,
+      getDataOptionsWithFetching: () => DATA_OPTIONS_LOAD_FAILED,
+    });
+
+    expect(getByTestId('fallback-input')).toBeVisible();
   });
 
   it('normalizes boolean string value', () => {
@@ -214,6 +230,26 @@ describe('SelectionContainer', () => {
     const props = mockComponent.mock.calls[0][0];
 
     expect(props.dataOptions[0].disabled).toBe(true);
+  });
+
+  it('passes valueSourceApi to getDataOptionsWithFetching', () => {
+    const getDataOptionsWithFetching = jest.fn(() => []);
+    const valueSourceApi = { path: '/value-source-api' };
+
+    renderSelectionContainer({
+      component: jest.fn(() => null),
+      valueSourceApi,
+      getDataOptionsWithFetching,
+    });
+
+    expect(getDataOptionsWithFetching).toHaveBeenCalledWith(
+      'test',
+      undefined,
+      '',
+      [],
+      undefined,
+      valueSourceApi,
+    );
   });
 
   it('updates searchValue from pendingSearchRef in useEffect', () => {

--- a/src/QueryBuilder/QueryBuilder/helpers/getControlTypes.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/getControlTypes.js
@@ -16,9 +16,10 @@ export const getControlType = ({
   dataType,
   operator,
   source,
+  valueSourceApi,
   availableValues,
 }) => {
-  const hasOptions = Boolean(source || availableValues?.length);
+  const hasOptions = Boolean(source || valueSourceApi || availableValues?.length);
 
   const isIn = operator === OPERATORS.IN || operator === OPERATORS.NOT_IN;
   const isEqual =

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -10,6 +10,7 @@ import {
   booleanOptions,
   getFieldOptions,
   getOperatorOptions,
+  hasValueOptions,
   REPEATABLE_FIELD_DELIMITER,
   sourceTemplate,
 } from './selectOptions';
@@ -204,7 +205,7 @@ const createDeletedFieldResponse = (boolean, fieldOptions) => {
 };
 
 const formatArrayValue = (value, hasSourceOrValues, possibleValues) => {
-  if (!hasSourceOrValues) {
+  if (!hasSourceOrValues || !Array.isArray(possibleValues)) {
     return value;
   }
 
@@ -217,6 +218,10 @@ const formatArrayValue = (value, hasSourceOrValues, possibleValues) => {
 };
 
 const formatSingleValue = (value, possibleValues, preserveQueryValue) => {
+  if (!Array.isArray(possibleValues)) {
+    return undefined;
+  }
+
   const key = preserveQueryValue ? 'value' : 'label';
 
   return possibleValues?.find(param => param.value === value)?.[key];
@@ -248,18 +253,19 @@ const getFormattedSourceField = async ({
     return createDeletedFieldResponse(boolean, fieldOptions);
   }
 
-  const { dataType, values, source } = fieldItem;
-  const hasSourceOrValues = values || source;
+  const { dataType, values, source, valueSourceApi } = fieldItem;
+  const hasSourceOrValues = hasValueOptions(fieldItem);
 
   let possibleValues = values;
 
-  if (source) {
+  if (source || valueSourceApi) {
     possibleValues = await getDataOptionsWithFetching(
       field,
       source,
       '',
       Array.isArray(value) ? value : [value],
       originalEntityTypeId,
+      valueSourceApi,
     );
   }
 
@@ -280,7 +286,12 @@ const getFormattedSourceField = async ({
       }),
       current: operator,
     },
-    value: { current: formattedValue || value, source, options: values },
+    value: {
+      current: formattedValue || value,
+      source,
+      valueSourceApi,
+      options: values,
+    },
   };
 };
 

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -4,6 +4,7 @@ import { OPERATORS } from '../../../constants/operators';
 import { fieldOptions } from '../../../../test/jest/data/entityType';
 import { DATA_TYPES } from '../../../constants/dataTypes';
 import { COLUMN_KEYS } from '../../../constants/columnKeys';
+import { DATA_OPTIONS_LOAD_FAILED } from '../../../hooks/useDataOptions';
 
 describe('fqlQueryToSource()', () => {
   test('should return empty array for empty query', async () => {
@@ -263,6 +264,7 @@ describe('fqlQueryToSource()', () => {
       '',
       ['value1', 'value2'],
       'entity-type-id',
+      undefined,
     );
 
     expect(result).toEqual([
@@ -280,6 +282,94 @@ describe('fqlQueryToSource()', () => {
         },
       },
     ]);
+  });
+
+  it('should fetch possible values when field has valueSourceApi and no source', async () => {
+    const intl = { formatMessage: jest.fn() };
+    const valueSourceApi = { path: '/value-source-api' };
+    const getDataOptionsWithFetching = jest.fn(() => Promise.resolve([
+      { value: 'value1', label: 'Label 1' },
+      { value: 'value2', label: 'Label 2' },
+    ]));
+
+    const fieldOptionsWithValueSourceApi = [{
+      value: 'user_first_name',
+      label: 'User first name',
+      dataType: DATA_TYPES.StringType,
+      valueSourceApi,
+    }];
+
+    const initialValuesWithValueSourceApi = {
+      user_first_name: { $in: ['value1', 'value2'] },
+    };
+
+    const result = await fqlQueryToSource({
+      initialValues: initialValuesWithValueSourceApi,
+      fieldOptions: fieldOptionsWithValueSourceApi,
+      intl,
+      getDataOptionsWithFetching,
+      preserveQueryValue: false,
+      originalEntityTypeId: 'entity-type-id',
+    });
+
+    expect(getDataOptionsWithFetching).toHaveBeenCalledWith(
+      'user_first_name',
+      undefined,
+      '',
+      ['value1', 'value2'],
+      'entity-type-id',
+      valueSourceApi,
+    );
+
+    expect(result).toEqual([
+      {
+        boolean: { options: booleanOptions, current: '' },
+        field: { options: fieldOptionsWithValueSourceApi, current: 'user_first_name', dataType: DATA_TYPES.StringType },
+        operator: { options: expect.any(Array), current: OPERATORS.IN, dataType: DATA_TYPES.StringType },
+        value: {
+          current: [
+            { value: 'value1', label: 'Label 1' },
+            { value: 'value2', label: 'Label 2' },
+          ],
+          source: undefined,
+          valueSourceApi,
+          options: undefined,
+        },
+      },
+    ]);
+  });
+
+  it('should preserve query value when valueSourceApi possible values fail to load', async () => {
+    const intl = { formatMessage: jest.fn() };
+    const valueSourceApi = { path: '/value-source-api' };
+    const getDataOptionsWithFetching = jest.fn(() => Promise.resolve(DATA_OPTIONS_LOAD_FAILED));
+
+    const fieldOptionsWithValueSourceApi = [{
+      value: 'user_first_name',
+      label: 'User first name',
+      dataType: DATA_TYPES.StringType,
+      valueSourceApi,
+    }];
+
+    const initialValuesWithValueSourceApi = {
+      user_first_name: { $in: ['value1', 'value2'] },
+    };
+
+    const result = await fqlQueryToSource({
+      initialValues: initialValuesWithValueSourceApi,
+      fieldOptions: fieldOptionsWithValueSourceApi,
+      intl,
+      getDataOptionsWithFetching,
+      preserveQueryValue: false,
+      originalEntityTypeId: 'entity-type-id',
+    });
+
+    expect(result[0].value).toEqual({
+      current: ['value1', 'value2'],
+      source: undefined,
+      valueSourceApi,
+      options: undefined,
+    });
   });
 
   it('should preserve query value when preserveQueryValue is true', async () => {
@@ -383,6 +473,7 @@ describe('fqlQueryToSource()', () => {
       '',
       ['uuid-1', 'uuid-2'],
       'entity-type-id',
+      undefined,
     );
 
     expect(result).toHaveLength(1);

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -54,6 +54,10 @@ export const getFilledValues = (options) => {
   return options?.map(({ value, label }) => ({ value, label: label || value }));
 };
 
+export const hasValueOptions = ({ values, source, valueSourceApi } = {}) => (
+  Boolean(values || source || valueSourceApi)
+);
+
 const stringOperators = (hasSourceOrValues) => {
   return [
     { label: OPERATORS_LABELS.EQUAL, value: OPERATORS.EQUAL },
@@ -154,6 +158,7 @@ export const getFieldOptions = (options) => {
       value: o.name,
       dataType: o.dataType.dataType,
       source: o.source,
+      valueSourceApi: o.valueSourceApi,
       values: getFilledValues(o.values),
     }));
 };

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -68,6 +68,59 @@ describe('select options', () => {
     it('should be equal to result value', () => {
       expect(getFieldOptions(entityType?.columns)).toEqual(result);
     });
+
+    it('uses source when valueSourceApi is not present', () => {
+      const source = { name: 'organization', columnName: 'name' };
+
+      const [field] = getFieldOptions([{
+        name: 'organization_name',
+        queryable: true,
+        dataType: {
+          dataType: 'stringType',
+        },
+        labelAlias: 'Organization name',
+        source,
+      }]);
+
+      expect(field.source).toEqual(source);
+      expect(field.valueSourceApi).toBeUndefined();
+    });
+
+    it('uses valueSourceApi when source is not present', () => {
+      const valueSourceApi = { path: '/value-source-api' };
+
+      const [field] = getFieldOptions([{
+        name: 'user_full_name',
+        queryable: true,
+        dataType: {
+          dataType: 'stringType',
+        },
+        labelAlias: 'User full name',
+        valueSourceApi,
+      }]);
+
+      expect(field.source).toBeUndefined();
+      expect(field.valueSourceApi).toEqual(valueSourceApi);
+    });
+
+    it('keeps source and valueSourceApi separate when both are present', () => {
+      const source = { name: 'organization', columnName: 'name' };
+      const valueSourceApi = { path: '/value-source-api' };
+
+      const [field] = getFieldOptions([{
+        name: 'organization_name',
+        queryable: true,
+        dataType: {
+          dataType: 'stringType',
+        },
+        labelAlias: 'Organization name',
+        source,
+        valueSourceApi,
+      }]);
+
+      expect(field.source).toEqual(source);
+      expect(field.valueSourceApi).toEqual(valueSourceApi);
+    });
   });
 
   describe('getOperatorOptions', () => {

--- a/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/valueBuilder.js
@@ -85,11 +85,12 @@ export const retainValueOnOperatorChange = ({
   operator,
   newOperator,
   source,
+  valueSourceApi,
   availableValues,
   prevValue,
 }) => {
-  const prevType = getControlType({ dataType, operator, source, availableValues });
-  const newType = getControlType({ dataType, operator: newOperator, source, availableValues });
+  const prevType = getControlType({ dataType, operator, source, valueSourceApi, availableValues });
+  const newType = getControlType({ dataType, operator: newOperator, source, valueSourceApi, availableValues });
 
   if (!prevType || !newType) {
     return '';

--- a/src/hooks/useDataOptions.js
+++ b/src/hooks/useDataOptions.js
@@ -1,6 +1,17 @@
 import { useCallback, useState } from 'react';
 import { ORGANIZATIONS_TYPES } from '../constants/dataTypes';
 
+export const DATA_OPTIONS_LOAD_FAILED = Object.freeze({ dataOptionsLoadFailed: true });
+
+export const isDataOptionsLoadFailure = (options) => Boolean(options?.dataOptionsLoadFailed);
+
+const getRequestKey = (request) => JSON.stringify(request);
+
+const getDataOptionsLoadFailure = (requestKey) => ({
+  ...DATA_OPTIONS_LOAD_FAILED,
+  requestKey,
+});
+
 function getUniqueValues(a, b) {
   const uniqueValues = new Map();
 
@@ -9,6 +20,15 @@ function getUniqueValues(a, b) {
 
   return Array.from(uniqueValues.values()).toSorted((aa, bb) => aa.label.localeCompare(bb.label));
 }
+
+const isPendingOrFailedOptions = (options) => (
+  typeof options === 'object' && !Array.isArray(options)
+);
+
+const shouldUseCachedOptions = (options, fetchPromise, requestKey) => (
+  isPendingOrFailedOptions(options) &&
+  (!isDataOptionsLoadFailure(options) || !fetchPromise || options.requestKey === requestKey)
+);
 
 export function useDataOptions({ getParamsSource, getOrganizations }) {
   const [dataOptions, setDataOptions] = useState({});
@@ -20,27 +40,33 @@ export function useDataOptions({ getParamsSource, getOrganizations }) {
       allowPromises = false,
       fetchPromise = undefined,
       fetchIfValuesMissing = [],
+      requestKey = undefined,
     ) => {
+      const cachedOptions = dataOptions[field];
+
       if (
-        Array.isArray(dataOptions[field]) &&
+        Array.isArray(cachedOptions) &&
                 // check that all specially requested values are present
-                fetchIfValuesMissing.every((v) => !!dataOptions[field].find((o) => o.value === v))
+                fetchIfValuesMissing.every((v) => !!cachedOptions.find((o) => o.value === v))
       ) {
-        return dataOptions[field];
+        return cachedOptions;
       }
 
-      // only return promises if requested, to prevent non-async code from exploding here
+      // only return promises/failures if requested, to prevent non-async code from exploding here
       // we don't need to worry about fetchIfValuesMissing here as we will re-render once this promise is resolved,
       // and any missing ones will then be checked
-      if (typeof dataOptions[field] === 'object' && !Array.isArray(dataOptions[field])) {
-        return allowPromises ? dataOptions[field] : [];
+      if (shouldUseCachedOptions(cachedOptions, fetchPromise, requestKey)) {
+        return allowPromises ? cachedOptions : [];
       }
 
       // if we're provided a fetcher, atomically set it here and automatically put its value back
       if (fetchPromise) {
-        const existingValues = dataOptions[field] ?? [];
-
-        const promise = fetchPromise();
+        const existingValues = Array.isArray(cachedOptions) ? cachedOptions : [];
+        const promise = fetchPromise()
+          .then((newValues) => (Array.isArray(newValues)
+            ? getUniqueValues(existingValues, newValues)
+            : getDataOptionsLoadFailure(requestKey)))
+          .catch(() => getDataOptionsLoadFailure(requestKey));
 
         setDataOptions((prev) => ({
           ...prev,
@@ -50,14 +76,14 @@ export function useDataOptions({ getParamsSource, getOrganizations }) {
         promise.then((newValues) => {
           setDataOptions((prev) => ({
             ...prev,
-            [field]: getUniqueValues(existingValues, newValues),
+            [field]: newValues,
           }));
         });
 
         return promise;
       }
 
-      return dataOptions[field] ?? [];
+      return cachedOptions ?? [];
     },
     [dataOptions],
   );
@@ -65,10 +91,10 @@ export function useDataOptions({ getParamsSource, getOrganizations }) {
   const getDataOptionsWithFetching = useCallback(
     // usedIds are only for organization sources
     // `originalEntityTypeId` is the entityTypeId the user is building the query against
-    (fieldName, source, searchValue, usedIds, originalEntityTypeId) => {
-      if (!source) {
+    (fieldName, source, searchValue, usedIds = [], originalEntityTypeId, valueSourceApi) => {
+      if (!source && !valueSourceApi) {
         return getDataOptions(fieldName);
-      } else if (ORGANIZATIONS_TYPES.includes(source.name)) {
+      } else if (source && ORGANIZATIONS_TYPES.includes(source.name)) {
         return getDataOptions(
           fieldName,
           true,
@@ -89,6 +115,11 @@ export function useDataOptions({ getParamsSource, getOrganizations }) {
               return results.flat();
             },
           usedIds,
+          getRequestKey({
+            source: source.name,
+            columnName: source.columnName,
+            usedIds,
+          }),
         );
       } else {
         // If the entityType isn't known yet, don't attempt value fetching
@@ -105,6 +136,11 @@ export function useDataOptions({ getParamsSource, getOrganizations }) {
             searchValue,
           }).then((data) => data?.content),
           [],
+          getRequestKey({
+            entityTypeId: originalEntityTypeId,
+            columnName: fieldName,
+            searchValue,
+          }),
         );
       }
     },

--- a/src/hooks/useDataOptions.test.js
+++ b/src/hooks/useDataOptions.test.js
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from '@testing-library/react';
-import { useDataOptions } from './useDataOptions';
+import { DATA_OPTIONS_LOAD_FAILED, isDataOptionsLoadFailure, useDataOptions } from './useDataOptions';
 import { ORGANIZATIONS_TYPES } from '../constants/dataTypes';
 
 describe('useDataOptions', () => {
@@ -94,6 +94,117 @@ describe('useDataOptions', () => {
       result.current.getDataOptionsWithFetching('field', { name: 'non-org' }, '', [], 'entity-type-id');
 
       expect(getParamsSource).toHaveBeenCalled();
+    });
+
+    it('calls getParamsSource for valueSourceApi when source is not provided', () => {
+      const getParamsSource = jest.fn(() => Promise.resolve({ content: [] }));
+      const { result } = renderHook(() => useDataOptions({ getParamsSource }));
+
+      result.current.getDataOptionsWithFetching(
+        'field',
+        undefined,
+        'search-value',
+        [],
+        'entity-type-id',
+        { path: '/value-source-api' },
+      );
+
+      expect(getParamsSource).toHaveBeenCalledWith({
+        entityTypeId: 'entity-type-id',
+        columnName: 'field',
+        searchValue: 'search-value',
+      });
+    });
+
+    it('returns failed marker when valueSourceApi fetch rejects', async () => {
+      const getParamsSource = jest.fn(() => Promise.reject(new Error('request failed')));
+      const { result } = renderHook(() => useDataOptions({ getParamsSource }));
+
+      const promise = result.current.getDataOptionsWithFetching(
+        'field',
+        undefined,
+        'search-value',
+        [],
+        'entity-type-id',
+        { path: '/value-source-api' },
+      );
+
+      await expect(promise).resolves.toMatchObject(DATA_OPTIONS_LOAD_FAILED);
+      await waitFor(() => expect(isDataOptionsLoadFailure(result.current.getDataOptions('field', true))).toBe(true));
+      expect(result.current.getDataOptionsWithFetching(
+        'field',
+        undefined,
+        'search-value',
+        [],
+        'entity-type-id',
+        { path: '/value-source-api' },
+      )).toMatchObject(DATA_OPTIONS_LOAD_FAILED);
+      expect(getParamsSource).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries failed valueSourceApi fetches when the search request changes', async () => {
+      const retryValues = [{ value: 'retry-value', label: 'Retry value' }];
+      const getParamsSource = jest.fn()
+        .mockRejectedValueOnce(new Error('request failed'))
+        .mockResolvedValueOnce({ content: retryValues });
+      const { result } = renderHook(() => useDataOptions({ getParamsSource }));
+
+      const failedPromise = result.current.getDataOptionsWithFetching(
+        'field',
+        undefined,
+        'failed-search',
+        [],
+        'entity-type-id',
+        { path: '/value-source-api' },
+      );
+
+      await expect(failedPromise).resolves.toMatchObject(DATA_OPTIONS_LOAD_FAILED);
+      await waitFor(() => expect(isDataOptionsLoadFailure(result.current.getDataOptions('field', true))).toBe(true));
+
+      expect(result.current.getDataOptionsWithFetching(
+        'field',
+        undefined,
+        'failed-search',
+        [],
+        'entity-type-id',
+        { path: '/value-source-api' },
+      )).toMatchObject(DATA_OPTIONS_LOAD_FAILED);
+      expect(getParamsSource).toHaveBeenCalledTimes(1);
+
+      const retryPromise = result.current.getDataOptionsWithFetching(
+        'field',
+        undefined,
+        'retry-search',
+        [],
+        'entity-type-id',
+        { path: '/value-source-api' },
+      );
+
+      await expect(retryPromise).resolves.toEqual(retryValues);
+      expect(getParamsSource).toHaveBeenCalledTimes(2);
+      expect(getParamsSource).toHaveBeenLastCalledWith({
+        entityTypeId: 'entity-type-id',
+        columnName: 'field',
+        searchValue: 'retry-search',
+      });
+    });
+
+    it('uses source when both source and valueSourceApi are provided', () => {
+      const getParamsSource = jest.fn(() => Promise.resolve({ content: [] }));
+      const getOrganizations = jest.fn(() => Promise.resolve([]));
+      const { result } = renderHook(() => useDataOptions({ getParamsSource, getOrganizations }));
+
+      result.current.getDataOptionsWithFetching(
+        'field',
+        { name: ORGANIZATIONS_TYPES[0], columnName: 'name' },
+        'search-value',
+        ['org-id'],
+        'entity-type-id',
+        { path: '/value-source-api' },
+      );
+
+      expect(getOrganizations).toHaveBeenCalledWith(['org-id'], 'name');
+      expect(getParamsSource).not.toHaveBeenCalled();
     });
 
     it('does not call getParamsSource for non-org when originalEntityTypeId is missing', async () => {


### PR DESCRIPTION
## Purpose
This change makes it so we can simplify the configuration of many columns, reducing the amount of noise and potential for bugs.

## Approach
Add support for valueSourceApi, so that when the query builder sees that property (and no `source` property), it will still send a request to FQM for the available field values. When this field is present, it will retrieve the field values by asking FQM about the field containing the property, along with its associated entity type. If `source` is present, its settings will take precedence, rather than requesting for the current field, which maintains the previous behavior.

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [X] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [X] Code coverage on new code is 80% or greater
  - [X] Duplications on new code is 3% or less
  - [X] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [X] There are no breaking changes in this PR.

