### PR TITLE
[UIPQB-280] Show custom field labels in user-friendly queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [3.0.2] IN PROGRESS
 * [UIPQB-279](https://folio-org.atlassian.net/browse/UIPQB-279) Add support for fields containing a valueSourceApi property without a source property
+* [UIPQB-280](https://folio-org.atlassian.net/browse/UIPQB-280) Show labels for single-value custom field dropdowns in user-friendly queries
 
 ## [3.0.1](https://github.com/folio-org/ui-plugin-query-builder/tree/v3.0.1) (2026-05-13)
 * [UIPQB-271](https://folio-org.atlassian.net/browse/UIPQB-271) Disambiguate duplicate language labels in UI

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -19,7 +19,7 @@ import { valueBuilder } from './valueBuilder';
 
 export const DEFAULT_PREVIEW_INTERVAL = 3000;
 
-const getLabeledValue = (value, dataOptions) => {
+const getLabeledValue = (value, ...optionSets) => {
   if (typeof value === 'boolean') {
     return value;
   }
@@ -28,11 +28,17 @@ const getLabeledValue = (value, dataOptions) => {
     return '';
   }
 
+  if (value?.label) {
+    return value.label;
+  }
+
   if (Array.isArray(value)) {
     return value;
   }
 
-  const matchedOption = dataOptions?.find(option => option.value === value);
+  const matchedOption = optionSets
+    .flat()
+    .find(option => option?.value === value);
 
   return matchedOption ? matchedOption.label : value;
 };
@@ -43,7 +49,7 @@ export const getQueryStr = (rows, fieldOptions, intl, timezone, getDataOptions) 
     const field = row[COLUMN_KEYS.FIELD].current;
     const operator = row[COLUMN_KEYS.OPERATOR].current;
     const value = row[COLUMN_KEYS.VALUE].current;
-    const labeledValue = getLabeledValue(value, getDataOptions(field));
+    const labeledValue = getLabeledValue(value, row[COLUMN_KEYS.VALUE].options, getDataOptions(field));
     const builtValue = valueBuilder({ value: labeledValue, field, operator, fieldOptions, intl, timezone });
 
     const queryPiece = `(${findLabelByValue(row[COLUMN_KEYS.FIELD], field)} ${operator} ${builtValue})`;

--- a/src/QueryBuilder/QueryBuilder/helpers/query.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.js
@@ -28,10 +28,6 @@ const getLabeledValue = (value, ...optionSets) => {
     return '';
   }
 
-  if (value?.label) {
-    return value.label;
-  }
-
   if (Array.isArray(value)) {
     return value;
   }

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -524,8 +524,8 @@ describe('getQueryStr', () => {
   it('uses static option labels for single-value custom field values', () => {
     const customFieldOptions = [
       {
-        value: 'user_customfields._custom_field_123',
-        label: 'User custom field',
+        value: 'source._custom_field_123',
+        label: 'Custom field',
         dataType: DATA_TYPES.StringType,
         values: [
           { value: 'opt_1', label: 'Option 1' },
@@ -538,7 +538,7 @@ describe('getQueryStr', () => {
         boolean: { current: '' },
         field: {
           options: customFieldOptions,
-          current: 'user_customfields._custom_field_123',
+          current: 'source._custom_field_123',
         },
         operator: { current: OPERATORS.EQUAL },
         value: {
@@ -556,14 +556,14 @@ describe('getQueryStr', () => {
       jest.fn(() => []),
     );
 
-    expect(result).toBe('(User custom field == Option 1)');
+    expect(result).toBe('(Custom field == Option 1)');
   });
 
   it('uses async option labels for single-value source field values', () => {
     const sourceFieldOptions = [
       {
-        value: 'item_material_type',
-        label: 'Item material type',
+        value: 'field1',
+        label: 'Field 1',
         dataType: DATA_TYPES.StringType,
       },
     ];
@@ -572,11 +572,11 @@ describe('getQueryStr', () => {
         boolean: { current: '' },
         field: {
           options: sourceFieldOptions,
-          current: 'item_material_type',
+          current: 'field1',
         },
         operator: { current: OPERATORS.EQUAL },
         value: {
-          current: 'book',
+          current: 'value 1',
         },
       },
     ];
@@ -586,10 +586,10 @@ describe('getQueryStr', () => {
       sourceFieldOptions,
       { formatDate: jest.fn() },
       'UTC',
-      jest.fn(() => [{ value: 'book', label: 'Book' }]),
+      jest.fn(() => [{ value: 'value 1', label: 'Label 1' }]),
     );
 
-    expect(result).toBe('(item_material_type == Book)');
+    expect(result).toBe('(field1 == Label 1)');
   });
 });
 

--- a/src/QueryBuilder/QueryBuilder/helpers/query.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/query.test.js
@@ -1,4 +1,11 @@
-import { findMissingValues, getTransformedValue, isQueryValid, fqlQueryToSource, sourceToFqlQuery } from './query';
+import {
+  findMissingValues,
+  getQueryStr,
+  getTransformedValue,
+  isQueryValid,
+  fqlQueryToSource,
+  sourceToFqlQuery,
+} from './query';
 import { booleanOptions } from './selectOptions';
 import { OPERATORS } from '../../../constants/operators';
 import { fieldOptions } from '../../../../test/jest/data/entityType';
@@ -510,6 +517,79 @@ describe('fqlQueryToSource()', () => {
     expect(result[0].operator.current).toBe(OPERATORS.EQUAL);
     expect(result[1].field.current).toBe('user_full_name');
     expect(result[1].operator.current).toBe(OPERATORS.CONTAINS);
+  });
+});
+
+describe('getQueryStr', () => {
+  it('uses static option labels for single-value custom field values', () => {
+    const customFieldOptions = [
+      {
+        value: 'user_customfields._custom_field_123',
+        label: 'User custom field',
+        dataType: DATA_TYPES.StringType,
+        values: [
+          { value: 'opt_1', label: 'Option 1' },
+          { value: 'opt_2', label: 'Option 2' },
+        ],
+      },
+    ];
+    const rows = [
+      {
+        boolean: { current: '' },
+        field: {
+          options: customFieldOptions,
+          current: 'user_customfields._custom_field_123',
+        },
+        operator: { current: OPERATORS.EQUAL },
+        value: {
+          current: 'opt_1',
+          options: customFieldOptions[0].values,
+        },
+      },
+    ];
+
+    const result = getQueryStr(
+      rows,
+      customFieldOptions,
+      { formatDate: jest.fn() },
+      'UTC',
+      jest.fn(() => []),
+    );
+
+    expect(result).toBe('(User custom field == Option 1)');
+  });
+
+  it('uses async option labels for single-value source field values', () => {
+    const sourceFieldOptions = [
+      {
+        value: 'item_material_type',
+        label: 'Item material type',
+        dataType: DATA_TYPES.StringType,
+      },
+    ];
+    const rows = [
+      {
+        boolean: { current: '' },
+        field: {
+          options: sourceFieldOptions,
+          current: 'item_material_type',
+        },
+        operator: { current: OPERATORS.EQUAL },
+        value: {
+          current: 'book',
+        },
+      },
+    ];
+
+    const result = getQueryStr(
+      rows,
+      sourceFieldOptions,
+      { formatDate: jest.fn() },
+      'UTC',
+      jest.fn(() => [{ value: 'book', label: 'Book' }]),
+    );
+
+    expect(result).toBe('(item_material_type == Book)');
   });
 });
 


### PR DESCRIPTION
## Purpose
[UIPQB-280](https://folio-org.atlassian.net/browse/UIPQB-280): Fix user-friendly query for queries involving custom fields


## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.