### PR TITLE
[UIPQB-282] Stop hiding fields used as idColumnName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-plugin-query-builder
 
+## [3.0.3] IN PROGRESS
+* [UIPQB-282](https://folio-org.atlassian.net/browse/UIPQB-282) Stop hiding fields used as idColumnName
+
 ## [3.0.2](https://github.com/folio-org/ui-plugin-query-builder/tree/v3.0.2) (2026-06-03)
 * [UIPQB-279](https://folio-org.atlassian.net/browse/UIPQB-279) Add support for fields containing a valueSourceApi property without a source property
 * [UIPQB-280](https://folio-org.atlassian.net/browse/UIPQB-280) Show labels for single-value custom field dropdowns in user-friendly queries

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -121,10 +121,7 @@ export const getOperatorOptions = ({
 };
 
 export const getColumnsWithProperties = (columns = []) => {
-  const ids = columns.filter(o => Boolean(o.idColumnName)).map(o => o.idColumnName) || [];
-
   return columns
-    .filter((o) => !ids.includes(o.name))
     .reduce((acc, item) => {
       if (item.queryable) {
         acc.push(item);

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -594,7 +594,7 @@ describe('getColumnsWithProperties', () => {
     expect(getColumnsWithProperties([])).toEqual([]);
   });
 
-  test('filters out columns whose name is listed as some item’s idColumnName', () => {
+  test('includes queryable columns whose name is listed as some item’s idColumnName', () => {
     const columns = [
       { name: 'meta', idColumnName: 'userId' },
       { name: 'userId', queryable: true },
@@ -603,7 +603,7 @@ describe('getColumnsWithProperties', () => {
 
     const res = getColumnsWithProperties(columns);
 
-    expect(res.map((i) => i.name)).toEqual(['displayName']);
+    expect(res.map((i) => i.name)).toEqual(['userId', 'displayName']);
   });
 
   test('includes only top-level items with queryable === true', () => {


### PR DESCRIPTION
## Purpose
[UIPQB-282](https://folio-org.atlassian.net/browse/UIPQB-282): Stop hiding fields used as idColumnName

## Pre-Merge Checklist
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.
