### PR TITLE
[UIPQB-281] Implement fuzzy matching within "Field" dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-plugin-query-builder
 
 ## [3.0.3] IN PROGRESS
+* [UIPQB-281](https://folio-org.atlassian.net/browse/UIPQB-281) Implement fuzzy matching within "Field" dropdown
 * [UIPQB-282](https://folio-org.atlassian.net/browse/UIPQB-282) Stop hiding fields used as idColumnName
 * [UIPQB-286](https://folio-org.atlassian.net/browse/UIPQB-286) Fix incorrect value display for 'Organization - Code' queries
 

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/RepeatableFields/RepeatableFields.js
@@ -20,6 +20,7 @@ import {
   booleanOptions,
   getFieldOptions,
   getFilteredOptions,
+  fuzzyOptionFormatter,
   getOperatorOptions,
   hasValueOptions,
   REPEATABLE_FIELD_DELIMITER,
@@ -223,6 +224,7 @@ export const RepeatableFields = memo(({ source, setSource, columns, entityTypeId
                   dataOptions={row.field.options}
                   value={row.field.current}
                   onFilter={getFilteredOptions}
+                  formatter={fuzzyOptionFormatter}
                   onChange={(value) => handleChange(value, index, COLUMN_KEYS.FIELD)}
                 />
               </Col>

--- a/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.js
+++ b/src/QueryBuilder/QueryBuilder/QueryBuilderModal/SelectionContainer/SelectionContainer.js
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
-import fuzzysort from 'fuzzysort';
 
-import { Loading, OptionSegment } from '@folio/stripes/components';
+import { Loading } from '@folio/stripes/components';
 
 import { RootContext } from '../../../../context/RootContext';
 import { ORGANIZATIONS_TYPES } from '../../../../constants/dataTypes';
 import { isDataOptionsLoadFailure } from '../../../../hooks/useDataOptions';
+import { fuzzyOptionFormatter, fuzzySortOptions } from '../../helpers/selectOptions';
 
 export const SelectionContainer = ({
   fieldName,
@@ -75,21 +75,6 @@ export const SelectionContainer = ({
     }
   }, [searchValue]);
 
-  const fuzzySort = useCallback((searchTerm, list) => {
-    if (!searchTerm) return list;
-
-    const results = [...fuzzysort.go(searchTerm, list, { key: 'label' })];
-
-    // Score descending, then label ascending for ties
-    results.sort((a, b) => {
-      if (a.score === b.score) return a.target.localeCompare(b.target);
-
-      return -(a.score - b.score);
-    });
-
-    return results.map(result => result.obj);
-  }, []);
-
   const prepareSearch = useCallback((filterText = '') => {
     pendingSearchRef.current = filterText;
 
@@ -98,43 +83,17 @@ export const SelectionContainer = ({
 
   // For Selection (single value): onFilter must return a plain array
   const singleValueFilterOptions = useCallback(
-    (filterText, list) => fuzzySort(prepareSearch(filterText), list), [fuzzySort, prepareSearch],
+    (filterText, list) => fuzzySortOptions(prepareSearch(filterText), list), [prepareSearch],
   );
 
   // For MultiSelection (multiple values): filter must return { renderedItems, exactMatch }
   const multiValueFilterOptions = useCallback((filterText, list) => {
     const searchTerm = prepareSearch(filterText);
-    const renderedItems = fuzzySort(searchTerm, list);
+    const renderedItems = fuzzySortOptions(searchTerm, list);
     const exactMatch = list.some(item => item.label?.toLowerCase() === searchTerm.toLowerCase());
 
     return { renderedItems, exactMatch };
-  }, [fuzzySort, prepareSearch]);
-
-  const fuzzyFormatter = useCallback(({ option, searchTerm }) => {
-    if (!option?.label) {
-      return null;
-    }
-
-    if (typeof searchTerm !== 'string' || searchTerm === '') {
-      return <OptionSegment>{option.label}</OptionSegment>;
-    }
-
-    const result = fuzzysort.single(searchTerm, option.label);
-
-    if (!result) {
-      return <OptionSegment>{option.label}</OptionSegment>;
-    }
-
-    return (
-      <OptionSegment>
-        {fuzzysort.highlight(result, (match, i) => (
-          <span key={i} className="mark---opJNO">
-            {match}
-          </span>
-        ))}
-      </OptionSegment>
-    );
-  }, []);
+  }, [prepareSearch]);
 
   const dataOptions = useMemo(() => {
     if (Array.isArray(optionsPromise)) {
@@ -167,7 +126,7 @@ export const SelectionContainer = ({
         {...filterProps}
         value={normalizedValue}
         onChange={handleOnChange}
-        formatter={fuzzyFormatter}
+        formatter={fuzzyOptionFormatter}
         placeholder={isMulti ? undefined : valuePlaceholder}
         dataOptions={dataOptions}
         emptyMessage={emptyMessage}

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -178,11 +178,16 @@ export const sourceTemplate = (fieldOptions = []) => ({
   [COLUMN_KEYS.VALUE]: { current: '' },
 });
 
-// Normalize dash-like Unicode characters so hyphen, en dash, em dash, etc. match each other
+// Normalize search text so dash variants match and noisy punctuation does not block fuzzy matches.
 const DASH_CHARS = /[\u2010-\u2015\u2212]/g;
+const IGNORED_SEARCH_CHARS = /[^\p{L}\p{N}\s-]/gu;
+
+const normalizeDashCharacters = (value) => (
+  typeof value === 'string' ? value.replace(DASH_CHARS, '-') : value
+);
 
 const normalizeSearchText = (value) => (
-  typeof value === 'string' ? value.replace(DASH_CHARS, '-') : value
+  typeof value === 'string' ? normalizeDashCharacters(value).replace(IGNORED_SEARCH_CHARS, '') : value
 );
 
 const getMatchRanges = (indexes) => {
@@ -229,9 +234,11 @@ export const fuzzySortOptions = (searchTerm, list) => {
   if (!searchTerm) return list;
 
   const normalizedSearchTerm = normalizeSearchText(searchTerm);
+  if (!normalizedSearchTerm) return list;
+
   const searchableList = list.map((option) => ({
     option,
-    label: normalizeSearchText(option.label),
+    label: normalizeDashCharacters(option.label),
   }));
   const results = [...fuzzysort.go(normalizedSearchTerm, searchableList, { key: 'label' })];
 
@@ -261,7 +268,11 @@ export const fuzzyOptionFormatter = ({ option, searchTerm }) => {
   }
 
   const normalizedSearchTerm = normalizeSearchText(searchTerm);
-  const normalizedLabel = normalizeSearchText(option.label);
+  if (!normalizedSearchTerm) {
+    return <OptionSegment>{option.label}</OptionSegment>;
+  }
+
+  const normalizedLabel = normalizeDashCharacters(option.label);
   const result = fuzzysort.single(normalizedSearchTerm, normalizedLabel);
 
   if (!result) {

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -209,7 +209,7 @@ const getHighlightedLabel = (label, indexes) => {
     }
 
     highlightedLabel.push(
-      <span key={i} className="mark---opJNO">
+      <span key={`${start}-${end}`} className="mark---opJNO">
         {label.slice(start, end + 1)}
       </span>,
     );

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -1,4 +1,6 @@
+import fuzzysort from 'fuzzysort';
 import { FormattedMessage } from 'react-intl';
+import { OptionSegment } from '@folio/stripes/components';
 import { DATA_TYPES } from '../../../constants/dataTypes';
 import { BOOLEAN_OPERATORS, OPERATORS, OPERATORS_LABELS } from '../../../constants/operators';
 import { COLUMN_KEYS } from '../../../constants/columnKeys';
@@ -176,13 +178,45 @@ export const sourceTemplate = (fieldOptions = []) => ({
   [COLUMN_KEYS.VALUE]: { current: '' },
 });
 
-export const getFilteredOptions = (value, dataOptions) => {
-  // Retain letters (from any language), numbers, spaces, and specific special characters (em dash, en dash, hyphen).
-  const cleanedValue = value.replace(/[^\p{L}\p{N}\s—–-]/gu, '');
+export const fuzzySortOptions = (searchTerm, list) => {
+  if (!searchTerm) return list;
 
-  // create a case-insensitive regex using the cleaned value.
-  const regex = new RegExp(cleanedValue, 'i');
+  const results = [...fuzzysort.go(searchTerm, list, { key: 'label' })];
 
-  // filter options based on whether the label matches the simplified pattern.
-  return dataOptions.filter(option => regex.test(option.label));
+  // Score descending, then label ascending for ties
+  results.sort((a, b) => {
+    if (a.score === b.score) return a.target.localeCompare(b.target);
+
+    return -(a.score - b.score);
+  });
+
+  return results.map(result => result.obj);
+};
+
+export const getFilteredOptions = fuzzySortOptions;
+
+export const fuzzyOptionFormatter = ({ option, searchTerm }) => {
+  if (!option?.label) {
+    return null;
+  }
+
+  if (typeof searchTerm !== 'string' || searchTerm === '') {
+    return <OptionSegment>{option.label}</OptionSegment>;
+  }
+
+  const result = fuzzysort.single(searchTerm, option.label);
+
+  if (!result) {
+    return <OptionSegment>{option.label}</OptionSegment>;
+  }
+
+  return (
+    <OptionSegment>
+      {fuzzysort.highlight(result, (match, i) => (
+        <span key={i} className="mark---opJNO">
+          {match}
+        </span>
+      ))}
+    </OptionSegment>
+  );
 };

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -188,7 +188,7 @@ const getMatchRanges = (indexes = []) => {
   return Array.from(indexes).reduce((ranges, index) => {
     const lastRange = ranges[ranges.length - 1];
 
-    if (lastRange && lastRange.end === index - 1) {
+    if (lastRange?.end === index - 1) {
       lastRange.end = index;
     } else {
       ranges.push({ start: index, end: index });

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -178,10 +178,61 @@ export const sourceTemplate = (fieldOptions = []) => ({
   [COLUMN_KEYS.VALUE]: { current: '' },
 });
 
+const DASH_CHARS = /[\u2010-\u2015\u2212]/g;
+
+const normalizeSearchText = (value) => (
+  typeof value === 'string' ? value.replace(DASH_CHARS, '-') : value
+);
+
+const getMatchRanges = (indexes = []) => {
+  return Array.from(indexes).reduce((ranges, index) => {
+    const lastRange = ranges[ranges.length - 1];
+
+    if (lastRange && lastRange.end === index - 1) {
+      lastRange.end = index;
+    } else {
+      ranges.push({ start: index, end: index });
+    }
+
+    return ranges;
+  }, []);
+};
+
+const getHighlightedLabel = (label, indexes) => {
+  const ranges = getMatchRanges(indexes);
+  const highlightedLabel = [];
+  let cursor = 0;
+
+  ranges.forEach(({ start, end }, i) => {
+    if (cursor < start) {
+      highlightedLabel.push(label.slice(cursor, start));
+    }
+
+    highlightedLabel.push(
+      <span key={i} className="mark---opJNO">
+        {label.slice(start, end + 1)}
+      </span>,
+    );
+
+    cursor = end + 1;
+  });
+
+  if (cursor < label.length) {
+    highlightedLabel.push(label.slice(cursor));
+  }
+
+  return highlightedLabel;
+};
+
 export const fuzzySortOptions = (searchTerm, list) => {
   if (!searchTerm) return list;
 
-  const results = [...fuzzysort.go(searchTerm, list, { key: 'label' })];
+  const normalizedSearchTerm = normalizeSearchText(searchTerm);
+  const searchableList = list.map((option) => ({
+    option,
+    label: normalizeSearchText(option.label),
+  }));
+  const results = [...fuzzysort.go(normalizedSearchTerm, searchableList, { key: 'label' })];
 
   // Score descending, then label ascending for ties
   results.sort((a, b) => {
@@ -190,7 +241,7 @@ export const fuzzySortOptions = (searchTerm, list) => {
     return -(a.score - b.score);
   });
 
-  return results.map(result => result.obj);
+  return results.map(result => result.obj.option);
 };
 
 export const getFilteredOptions = fuzzySortOptions;
@@ -204,7 +255,13 @@ export const fuzzyOptionFormatter = ({ option, searchTerm }) => {
     return <OptionSegment>{option.label}</OptionSegment>;
   }
 
-  const result = fuzzysort.single(searchTerm, option.label);
+  if (typeof option.label !== 'string') {
+    return <OptionSegment>{option.label}</OptionSegment>;
+  }
+
+  const normalizedSearchTerm = normalizeSearchText(searchTerm);
+  const normalizedLabel = normalizeSearchText(option.label);
+  const result = fuzzysort.single(normalizedSearchTerm, normalizedLabel);
 
   if (!result) {
     return <OptionSegment>{option.label}</OptionSegment>;
@@ -212,11 +269,7 @@ export const fuzzyOptionFormatter = ({ option, searchTerm }) => {
 
   return (
     <OptionSegment>
-      {fuzzysort.highlight(result, (match, i) => (
-        <span key={i} className="mark---opJNO">
-          {match}
-        </span>
-      ))}
+      {getHighlightedLabel(option.label, fuzzysort.indexes(result))}
     </OptionSegment>
   );
 };

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -185,7 +185,7 @@ const normalizeSearchText = (value) => (
   typeof value === 'string' ? value.replace(DASH_CHARS, '-') : value
 );
 
-const getMatchRanges = (indexes = []) => {
+const getMatchRanges = (indexes) => {
   return Array.from(indexes).reduce((ranges, index) => {
     const lastRange = ranges[ranges.length - 1];
 

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -234,6 +234,7 @@ export const fuzzySortOptions = (searchTerm, list) => {
   if (!searchTerm) return list;
 
   const normalizedSearchTerm = normalizeSearchText(searchTerm);
+
   if (!normalizedSearchTerm) return list;
 
   const searchableList = list.map((option) => ({
@@ -268,6 +269,7 @@ export const fuzzyOptionFormatter = ({ option, searchTerm }) => {
   }
 
   const normalizedSearchTerm = normalizeSearchText(searchTerm);
+
   if (!normalizedSearchTerm) {
     return <OptionSegment>{option.label}</OptionSegment>;
   }

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -203,7 +203,7 @@ const getHighlightedLabel = (label, indexes) => {
   const highlightedLabel = [];
   let cursor = 0;
 
-  ranges.forEach(({ start, end }, i) => {
+  ranges.forEach(({ start, end }) => {
     if (cursor < start) {
       highlightedLabel.push(label.slice(cursor, start));
     }

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.js
@@ -178,6 +178,7 @@ export const sourceTemplate = (fieldOptions = []) => ({
   [COLUMN_KEYS.VALUE]: { current: '' },
 });
 
+// Normalize dash-like Unicode characters so hyphen, en dash, em dash, etc. match each other
 const DASH_CHARS = /[\u2010-\u2015\u2212]/g;
 
 const normalizeSearchText = (value) => (

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -588,6 +588,17 @@ describe('getFilteredOptions', () => {
     expect(res).toEqual([{ label: 'Items — Holdings — Statements' }]);
   });
 
+  test('should sort equal-score matches by label', () => {
+    const res = getFilteredOptions('x', [
+      { label: 'Cx' },
+      { label: 'Dx' },
+      { label: 'Bx' },
+      { label: 'Ax' },
+    ]);
+
+    expect(res.map(({ label }) => label)).toEqual(['Ax', 'Bx', 'Cx', 'Dx']);
+  });
+
   test('should return all options if input value is an empty string', () => {
     const res = getFilteredOptions('', mockDataOptions);
 
@@ -617,6 +628,16 @@ describe('getFilteredOptions', () => {
     });
 
     expect(element.props.children[0].props.children).toBe('Items — Holdings');
+  });
+
+  test('should render non-string labels without highlighting', () => {
+    const label = <span>Formatted label</span>;
+    const element = fuzzyOptionFormatter({
+      option: { label },
+      searchTerm: 'Formatted',
+    });
+
+    expect(element.props.children).toBe(label);
   });
 
   test('should not reuse stale fuzzy indexes when formatting a shorter dash match', () => {

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -621,6 +621,24 @@ describe('getFilteredOptions', () => {
     expect(res).toEqual(mockDataOptions);
   });
 
+  test('should ignore non-string labels while filtering', () => {
+    const label = <span>Formatted label</span>;
+    const res = getFilteredOptions('Alpha', [
+      { label },
+      { label: 'Alpha' },
+    ]);
+
+    expect(res).toEqual([{ label: 'Alpha' }]);
+  });
+
+  test('should return no matches for non-string search terms', () => {
+    const res = getFilteredOptions(123, [
+      { label: '123' },
+    ]);
+
+    expect(res).toEqual([]);
+  });
+
   test('should return an empty array if no options match', () => {
     const res = getFilteredOptions('no such option present', mockDataOptions);
 
@@ -654,6 +672,15 @@ describe('getFilteredOptions', () => {
     });
 
     expect(element.props.children).toBe(label);
+  });
+
+  test('should render unhighlighted labels when the search term only contains ignored special characters', () => {
+    const element = fuzzyOptionFormatter({
+      option: { label: 'Alpha' },
+      searchTerm: '!*?',
+    });
+
+    expect(element.props.children).toBe('Alpha');
   });
 
   test('should not reuse stale fuzzy indexes when formatting a shorter dash match', () => {

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -546,21 +546,21 @@ describe('getFilteredOptions', () => {
     expect(res).toEqual([{ label: 'Items — Instances — Updated date' }]);
   });
 
-  test('should ignore other special characters but still match meaningful content', () => {
-    // Ignore special characters like '*' and '!', and match only the meaningful content.
-    const res = getFilteredOptions('Items — Ins*tan!ces — Upd?ate.', mockDataOptions);
+  test('should support fuzzy matching for non-contiguous input', () => {
+    const res = getFilteredOptions('InstUpd', mockDataOptions);
 
     expect(res).toEqual([{ label: 'Items — Instances — Updated date' }]);
   });
 
-  test('should return entire list if put "—"', () => {
+  test('should return all matching options if put "—"', () => {
     const res = getFilteredOptions('—', mockDataOptions);
 
-    expect(res).toEqual(mockDataOptions);
+    expect(res).toHaveLength(mockDataOptions.length);
+    expect(res).toEqual(expect.arrayContaining(mockDataOptions));
   });
 
   test('should match values case-insensitively', () => {
-    const res = getFilteredOptions(' — statements', mockDataOptions);
+    const res = getFilteredOptions('statements', mockDataOptions);
 
     expect(res).toEqual([{ label: 'Items — Holdings — Statements' }]);
   });

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -577,11 +577,25 @@ describe('getFilteredOptions', () => {
     expect(res).toEqual([{ label: 'Items — Instances — Updated date' }]);
   });
 
+  test('should ignore unsupported special characters in search terms', () => {
+    const res = getFilteredOptions('Parent ! Child', [
+      { label: 'Parent Child' },
+    ]);
+
+    expect(res).toEqual([{ label: 'Parent Child' }]);
+  });
+
   test('should return all matching options if put "—"', () => {
     const res = getFilteredOptions('—', mockDataOptions);
 
     expect(res).toHaveLength(mockDataOptions.length);
     expect(res).toEqual(expect.arrayContaining(mockDataOptions));
+  });
+
+  test('should return all options when search term only contains ignored special characters', () => {
+    const res = getFilteredOptions('!*?', mockDataOptions);
+
+    expect(res).toEqual(mockDataOptions);
   });
 
   test('should match values case-insensitively', () => {

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -2,10 +2,19 @@ import {
   getColumnsWithProperties,
   getFieldOptions,
   getFilteredOptions,
+  fuzzyOptionFormatter,
   getOperatorOptions,
 } from './selectOptions';
 import { DATA_TYPES } from '../../../constants/dataTypes';
 import { OPERATORS, OPERATORS_LABELS } from '../../../constants/operators';
+
+const getElementText = (node) => {
+  if (!node) return '';
+  if (typeof node === 'string') return node;
+  if (Array.isArray(node)) return node.map(getElementText).join('');
+
+  return getElementText(node.props?.children);
+};
 
 const entityType = {
   columns: [
@@ -546,6 +555,20 @@ describe('getFilteredOptions', () => {
     expect(res).toEqual([{ label: 'Items — Instances — Updated date' }]);
   });
 
+  test('should match hyphen input against em dash labels', () => {
+    const res = getFilteredOptions('Instances - Updated date', mockDataOptions);
+
+    expect(res).toEqual([{ label: 'Items — Instances — Updated date' }]);
+  });
+
+  test('should match em dash input against hyphen labels', () => {
+    const res = getFilteredOptions('項目 — 持股', [
+      { label: '項目 - 持股 - 報表' },
+    ]);
+
+    expect(res).toEqual([{ label: '項目 - 持股 - 報表' }]);
+  });
+
   test('should support fuzzy matching for non-contiguous input', () => {
     const res = getFilteredOptions('InstUpd', mockDataOptions);
 
@@ -585,6 +608,29 @@ describe('getFilteredOptions', () => {
     const res = getFilteredOptions('持股', mockDataOptionsChina);
 
     expect(res).toEqual([{ label: '項目 - 持股 - 報表' }]);
+  });
+
+  test('should preserve original label dashes when highlighting normalized dash matches', () => {
+    const element = fuzzyOptionFormatter({
+      option: { label: 'Items — Holdings' },
+      searchTerm: 'Items - Holdings',
+    });
+
+    expect(element.props.children[0].props.children).toBe('Items — Holdings');
+  });
+
+  test('should not reuse stale fuzzy indexes when formatting a shorter dash match', () => {
+    fuzzyOptionFormatter({
+      option: { label: 'User — Email' },
+      searchTerm: 'User - Email',
+    });
+
+    const element = fuzzyOptionFormatter({
+      option: { label: 'User — Email' },
+      searchTerm: '-',
+    });
+
+    expect(getElementText(element)).toBe('User — Email');
   });
 });
 

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -585,7 +585,7 @@ describe('getFilteredOptions', () => {
     expect(res).toEqual([{ label: 'Parent Child' }]);
   });
 
-  test('should return all matching options if put "—"', () => {
+  test('should return all options containing normalized dash characters', () => {
     const res = getFilteredOptions('—', mockDataOptions);
 
     expect(res).toHaveLength(mockDataOptions.length);

--- a/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
+++ b/src/QueryBuilder/QueryBuilder/helpers/selectOptions.test.js
@@ -556,17 +556,19 @@ describe('getFilteredOptions', () => {
   });
 
   test('should match hyphen input against em dash labels', () => {
-    const res = getFilteredOptions('Instances - Updated date', mockDataOptions);
+    const res = getFilteredOptions('Parent - Child', [
+      { label: 'Parent — Child' },
+    ]);
 
-    expect(res).toEqual([{ label: 'Items — Instances — Updated date' }]);
+    expect(res).toEqual([{ label: 'Parent — Child' }]);
   });
 
   test('should match em dash input against hyphen labels', () => {
-    const res = getFilteredOptions('項目 — 持股', [
-      { label: '項目 - 持股 - 報表' },
+    const res = getFilteredOptions('Parent — Child', [
+      { label: 'Parent - Child' },
     ]);
 
-    expect(res).toEqual([{ label: '項目 - 持股 - 報表' }]);
+    expect(res).toEqual([{ label: 'Parent - Child' }]);
   });
 
   test('should support fuzzy matching for non-contiguous input', () => {
@@ -623,11 +625,11 @@ describe('getFilteredOptions', () => {
 
   test('should preserve original label dashes when highlighting normalized dash matches', () => {
     const element = fuzzyOptionFormatter({
-      option: { label: 'Items — Holdings' },
-      searchTerm: 'Items - Holdings',
+      option: { label: 'Parent — Child' },
+      searchTerm: 'Parent - Child',
     });
 
-    expect(element.props.children[0].props.children).toBe('Items — Holdings');
+    expect(element.props.children[0].props.children).toBe('Parent — Child');
   });
 
   test('should render non-string labels without highlighting', () => {
@@ -642,16 +644,16 @@ describe('getFilteredOptions', () => {
 
   test('should not reuse stale fuzzy indexes when formatting a shorter dash match', () => {
     fuzzyOptionFormatter({
-      option: { label: 'User — Email' },
-      searchTerm: 'User - Email',
+      option: { label: 'Alpha — Beta' },
+      searchTerm: 'Alpha - Beta',
     });
 
     const element = fuzzyOptionFormatter({
-      option: { label: 'User — Email' },
+      option: { label: 'Alpha — Beta' },
       searchTerm: '-',
     });
 
-    expect(getElementText(element)).toBe('User — Email');
+    expect(getElementText(element)).toBe('Alpha — Beta');
   });
 });
 


### PR DESCRIPTION
## Purpose
[UIPQB-281](https://folio-org.atlassian.net/browse/UIPQB-281): Implement fuzzy matching within "Field" dropdown

Also: match hyphens to em-dashes in search filter

## Pre-Merge Checklist
Before merging this PR, please go through the following list and take appropriate actions.
- [x] I've added appropriate record to the CHANGELOG.md
- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.